### PR TITLE
Fix `get` for packed leaves

### DIFF
--- a/src/tests/packed.rs
+++ b/src/tests/packed.rs
@@ -1,4 +1,4 @@
-use crate::List;
+use crate::{interface::MutList, List};
 use ssz_types::VariableList;
 use tree_hash::TreeHash;
 use typenum::U16;
@@ -11,6 +11,10 @@ fn u64_packed_list_build_and_iter() {
 
         let from_iter = list.iter().copied().collect::<Vec<_>>();
         assert_eq!(vec, from_iter);
+
+        for i in 0..len as usize {
+            assert_eq!(list.get(i), vec.get(i));
+        }
     }
 }
 
@@ -23,4 +27,30 @@ fn u64_packed_list_tree_hash() {
 
         assert_eq!(list.tree_hash_root(), var_list.tree_hash_root());
     }
+}
+
+#[test]
+fn out_of_order_mutations() {
+    let mut vec = vec![0; 16];
+    let mut list = List::<u64, U16>::new(vec.clone()).unwrap();
+    let mutations = vec![
+        (4, 12),
+        (3, 900),
+        (0, 1),
+        (15, 2),
+        (13, 4),
+        (7, 17),
+        (9, 3),
+        (0, 5),
+        (6, 100),
+        (5, 42),
+    ];
+
+    for (i, v) in mutations {
+        list.replace(i, v).unwrap();
+        vec[i] = v;
+        assert_eq!(list.get(i), Some(&v));
+    }
+
+    assert_eq!(list.to_vec(), vec);
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -63,9 +63,10 @@ impl<T: TreeHash + Clone> Tree<T> {
                 values.get(index % T::tree_hash_packing_factor())
             }
             Self::Node { left, right, .. } if depth > 0 => {
+                let packing_depth = opt_packing_depth::<T>().unwrap_or(0);
                 let new_depth = depth - 1;
                 // Left
-                if (index >> new_depth) & 1 == 0 {
+                if (index >> (new_depth + packing_depth)) & 1 == 0 {
                     left.get(index, new_depth)
                 }
                 // Right


### PR DESCRIPTION
Add a missed condition to `get` that affects lookups when leaves are packed. Testing is also expanded slightly.

Thanks @pawanjay176 for finding the bug!