### PR TITLE
Use released SigP crates!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,34 +6,25 @@ edition = "2021"
 
 [dependencies]
 derivative = "2.2.0"
-eth2_hashing = "0.2.0"
-eth2_ssz = "0.4.0"
-eth2_ssz_derive = "0.3.0"
+ethereum_hashing = "1.0.0-beta.2"
+ethereum_ssz = "0.5.0"
+ethereum_ssz_derive = "0.5.0"
 itertools = "0.10.3"
 parking_lot = "0.11.2"
 rayon = "1.5.1"
 serde = { version = "1.0.0", features = ["derive"] }
-tree_hash = "0.4.0"
+tree_hash = "0.5.0"
 triomphe = "0.1.5"
 typenum = "1.14.0"
 vec_map = "0.8.2"
 smallvec = "1.8.0"
 
 [dev-dependencies]
-eth2_ssz_types = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
+ssz_types = "0.5.0"
 proptest = "1.0.0"
-tree_hash_derive = "0.4.0"
+tree_hash_derive = "0.5.0"
 criterion = "0.3"
 pprof = { version = "0.9.1", features = ["criterion", "flamegraph"] }
-
-[patch.crates-io]
-tree_hash = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
-tree_hash_derive = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
-eth2_ssz_types = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
-eth2_serde_utils = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
-eth2_ssz = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
-eth2_ssz_derive = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
-eth2_hashing = { git = "https://github.com/sigp/lighthouse.git", branch = "tree-states" }
 
 [profile.bench]
 debug = 1

--- a/src/tests/proptest/mod.rs
+++ b/src/tests/proptest/mod.rs
@@ -15,6 +15,7 @@ pub fn arb_index(n: usize) -> impl Strategy<Value = usize> {
 pub fn arb_list<T, N, S>(strategy: S) -> impl Strategy<Value = Vec<T>>
 where
     S: Strategy<Value = T>,
+    T: std::fmt::Debug,
     N: Unsigned + std::fmt::Debug,
 {
     proptest::collection::vec(strategy, 0..=N::to_usize())
@@ -23,6 +24,7 @@ where
 pub fn arb_vect<T, N, S>(strategy: S) -> impl Strategy<Value = Vec<T>>
 where
     S: Strategy<Value = T>,
+    T: std::fmt::Debug,
     N: Unsigned + std::fmt::Debug,
 {
     proptest::collection::vec(strategy, N::to_usize())

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,7 @@
 use crate::utils::{opt_hash, opt_packing_depth, opt_packing_factor};
 use crate::{Arc, Error, Leaf, PackedLeaf, UpdateMap};
 use derivative::Derivative;
-use eth2_hashing::{hash32_concat, ZERO_HASHES};
+use ethereum_hashing::{hash32_concat, ZERO_HASHES};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};


### PR DESCRIPTION
Remove all `patches` and `git` dependencies in favour of `sigp` crates from `crates.io`!