### PR TITLE
Implement rebasing

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -250,6 +250,12 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
 
         Ok(new)
     }
+
+    pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
+        let rebased = self.rebase(base)?;
+        *self = rebased;
+        Ok(())
+    }
 }
 
 impl<T: TreeHash + Clone, N: Unsigned> Default for List<T, N> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -151,6 +151,12 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
 
         Ok(new)
     }
+
+    pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
+        let rebased = self.rebase(base)?;
+        *self = rebased;
+        Ok(())
+    }
 }
 
 impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> From<Vector<T, N, U>> for List<T, N, U> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,3 +1,4 @@
+use crate::diff::{Diff, VectorDiff};
 use crate::interface::{ImmList, Interface, MutList};
 use crate::interface_iter::InterfaceIter;
 use crate::iter::Iter;
@@ -134,6 +135,21 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> TryFrom<List<T, N, U>> f
                 expected: N::to_usize(),
             })
         }
+    }
+}
+
+impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMap<T>>
+    Vector<T, N, U>
+{
+    pub fn rebase(&self, base: &Self) -> Result<Self, Error> {
+        // Diff self from base.
+        let diff = VectorDiff::compute_diff(base, self)?;
+
+        // Apply diff to base, yielding a new list rooted in base.
+        let mut new = base.clone();
+        diff.apply_diff(&mut new)?;
+
+        Ok(new)
     }
 }
 


### PR DESCRIPTION
This PR implements "rebasing", the act of re-rooting a List or Vect's tree so that it's based on another. This operation is useful if two related trees are created independently (e.g. due to a cache miss/load from disk), as it allows them to share more nodes and use less total memory.