### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check version
+        run: |
+          TAG_VERSION=$(echo ${GITHUB_REF#refs/tags/v})
+          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          test "$TAG_VERSION" = "$CRATE_VERSION"
+  publish:
+    runs-on: ubuntu-latest
+    needs: check-version
+    env:
+      CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish crate
+        run: cargo publish -p milhouse

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,44 @@
+name: test-suite
+
+on:
+  push:
+    branches:
+      - main
+      - 'pr/*'
+  pull_request:
+env:
+  # Deny warnings in CI
+  RUSTFLAGS: "-D warnings"
+jobs:
+  cargo-fmt:
+    name: cargo-fmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Check formatting with cargo fmt
+      run: cargo fmt --all -- --check
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Lint code for quality and style with Clippy
+      run: cargo clippy --all
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: test-${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Run tests
+      run: cargo test --release
+    - name: Check all examples, binaries, etc
+      run: cargo check --all-targets

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Cargo.lock
 
 /proptest-regressions
+
+# IntelliJ / Clion
+.idea

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -27,6 +27,7 @@ impl<'a, T: Clone> Cow<'a, T> {
 }
 
 pub trait CowTrait<'a, T: Clone>: Deref<Target = T> {
+    #[allow(clippy::wrong_self_convention)]
     fn to_mut(self) -> &'a mut T;
 }
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -176,7 +176,8 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
 impl<T: TreeHash + Clone, N: Unsigned> ImmList<T> for ListInner<T, N> {
     fn get(&self, index: usize) -> Option<&T> {
         if index < self.len().as_usize() {
-            self.tree.get_recursive(index, self.depth, self.packing_depth)
+            self.tree
+                .get_recursive(index, self.depth, self.packing_depth)
         } else {
             None
         }

--- a/src/list.rs
+++ b/src/list.rs
@@ -299,7 +299,7 @@ impl<'a, T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a
     }
 }
 
-impl<'a, T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Serialize for List<T, N, U>
+impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Serialize for List<T, N, U>
 where
     T: Serialize,
 {

--- a/src/tests/packed.rs
+++ b/src/tests/packed.rs
@@ -49,7 +49,7 @@ fn u64_packed_vector_tree_hash() {
     let len = 16;
     let vec = (0..len).map(|i| 2 * i).collect::<Vec<u64>>();
     let vector = Vector::<u64, U16>::new(vec.clone()).unwrap();
-    let fixed_vector = FixedVector::<u64, U16>::new(vec.clone()).unwrap();
+    let fixed_vector = FixedVector::<u64, U16>::new(vec).unwrap();
 
     assert_eq!(vector.tree_hash_root(), fixed_vector.tree_hash_root());
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -174,7 +174,8 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> From<Vector<T, N, U>> fo
 impl<T: TreeHash + Clone, N: Unsigned> ImmList<T> for VectorInner<T, N> {
     fn get(&self, index: usize) -> Option<&T> {
         if index < self.len().as_usize() {
-            self.tree.get_recursive(index, self.depth, self.packing_depth)
+            self.tree
+                .get_recursive(index, self.depth, self.packing_depth)
         } else {
             None
         }


### PR DESCRIPTION
This PR adds CI jobs for:
- `cargo fmt` 
- `cargo clippy`
- `cargo test`
- `cargo publish`