### PR TITLE
Remove unused dev-deps and fix Windows CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,3 @@ ethereum-types = { version = "0.14.1", features = ["arbitrary"] }
 ssz_types = "0.5.0"
 proptest = "1.0.0"
 tree_hash_derive = "0.5.0"
-criterion = "0.3"
-pprof = { version = "0.9.1", features = ["criterion", "flamegraph"] }
-
-[profile.bench]
-debug = 1


### PR DESCRIPTION
Fix the CI failure by removing `pprof` which wasn't being used anyway

Closes #15