### PR TITLE
Compute packed leaf hash on demand

### DIFF
--- a/src/tests/size_of.rs
+++ b/src/tests/size_of.rs
@@ -6,9 +6,9 @@ use tree_hash::Hash256;
 /// It's important that the Tree nodes have a predictable size.
 #[test]
 fn size_of_hash256() {
-    assert_eq!(size_of::<Tree<Hash256>>(), 72);
+    assert_eq!(size_of::<Tree<Hash256>>(), 64);
     assert_eq!(size_of::<Leaf<Hash256>>(), 48);
-    assert_eq!(size_of::<PackedLeaf<Hash256>>(), 64);
+    assert_eq!(size_of::<PackedLeaf<Hash256>>(), 24);
 
     let rw_lock_size = size_of::<RwLock<Hash256>>();
     assert_eq!(rw_lock_size, 40);
@@ -18,19 +18,19 @@ fn size_of_hash256() {
 
     assert_eq!(
         size_of::<Tree<Hash256>>(),
-        size_of::<PackedLeaf<Hash256>>() + 8
+        size_of::<PackedLeaf<Hash256>>() + 40
     );
 }
 
 /// It's important that the Tree nodes have a predictable size.
 #[test]
 fn size_of_u8() {
-    assert_eq!(size_of::<Tree<u8>>(), 72);
+    assert_eq!(size_of::<Tree<u8>>(), 64);
     assert_eq!(size_of::<Leaf<u8>>(), 48);
-    assert_eq!(size_of::<PackedLeaf<u8>>(), 64);
+    assert_eq!(size_of::<PackedLeaf<u8>>(), 24);
     assert_eq!(
         size_of::<PackedLeaf<u8>>(),
-        size_of::<RwLock<Hash256>>() + size_of::<Vec<u8>>()
+        size_of::<Vec<u8>>()
     );
 
     let rw_lock_size = size_of::<RwLock<u8>>();
@@ -39,5 +39,5 @@ fn size_of_u8() {
     let arc_size = size_of::<Arc<Tree<u8>>>();
     assert_eq!(arc_size, 8);
 
-    assert_eq!(size_of::<Tree<u8>>(), size_of::<PackedLeaf<u8>>() + 8);
+    assert_eq!(size_of::<Tree<u8>>(), size_of::<PackedLeaf<u8>>() + 40);
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -176,7 +176,7 @@ impl<T: TreeHash + Clone> Tree<T> {
                 Ok(Self::leaf_with_hash(value, hash))
             }
             Self::PackedLeaf(packed_leaf) if depth == 0 => Ok(Arc::new(Self::PackedLeaf(
-                packed_leaf.update(prefix, hash, updates)?,
+                packed_leaf.update(prefix, updates)?,
             ))),
             Self::Node { left, right, .. } if depth > 0 => {
                 let packing_depth = opt_packing_depth::<T>().unwrap_or(0);
@@ -217,7 +217,7 @@ impl<T: TreeHash + Clone> Tree<T> {
             Self::Zero(zero_depth) if *zero_depth == depth => {
                 if depth == 0 {
                     if opt_packing_factor::<T>().is_some() {
-                        let packed_leaf = PackedLeaf::empty().update(prefix, hash, updates)?;
+                        let packed_leaf = PackedLeaf::empty().update(prefix, updates)?;
                         Ok(Arc::new(Self::PackedLeaf(packed_leaf)))
                     } else {
                         let index = prefix;
@@ -270,8 +270,7 @@ impl<T: PartialEq + TreeHash + Clone + Encode + Decode> Tree<T> {
                     }
                 }
                 if !equal {
-                    let hash = *l2.hash.read();
-                    diff.hashes.insert((depth, prefix), hash);
+                    diff.hashes.insert((depth, prefix), l2.tree_hash());
                 }
                 Ok(())
             }
@@ -342,8 +341,7 @@ impl<T: PartialEq + TreeHash + Clone + Encode + Decode> Tree<T> {
                 Ok(())
             }
             Self::PackedLeaf(packed_leaf) if depth == 0 => {
-                diff.hashes
-                    .insert((depth, prefix), *packed_leaf.hash.read());
+                diff.hashes.insert((depth, prefix), packed_leaf.tree_hash());
                 for (i, value) in packed_leaf.values.iter().enumerate() {
                     diff.leaves.insert(prefix | i, value.clone());
                 }


### PR DESCRIPTION
Addresses #10

Keeps the `values` field and compute the `hash` field on demand.

Currently a WIP awaiting comparisons to keeping just the `hash` field and computing `values` on demand.