### PR TITLE
Compute packed leaf values on demand (Option 1)

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,8 +1,7 @@
 use crate::utils::{opt_packing_depth, opt_packing_factor, Length};
-use crate::{Arc, Error, PackedLeaf, Tree};
-use tree_hash::TreeHash;
+use crate::{Arc, Error, PackedLeaf, Tree, Value};
 
-pub struct Builder<T: TreeHash + Clone> {
+pub struct Builder<T: Value> {
     stack: Vec<Tree<T>>,
     depth: usize,
     length: Length,
@@ -12,7 +11,7 @@ pub struct Builder<T: TreeHash + Clone> {
     packing_depth: usize,
 }
 
-impl<T: TreeHash + Clone> Builder<T> {
+impl<T: Value> Builder<T> {
     pub fn new(depth: usize) -> Self {
         Self {
             stack: Vec::with_capacity(depth),

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow as StdCow;
 use std::collections::btree_map::VacantEntry;
 use std::ops::Deref;
 
@@ -33,7 +34,7 @@ pub trait CowTrait<'a, T: Clone>: Deref<Target = T> {
 
 pub enum BTreeCow<'a, T: Clone> {
     Immutable {
-        value: &'a T,
+        value: StdCow<'a, T>,
         entry: VacantEntry<'a, usize, T>,
     },
     Mutable {
@@ -44,7 +45,7 @@ pub enum BTreeCow<'a, T: Clone> {
 impl<'a, T: Clone> CowTrait<'a, T> for BTreeCow<'a, T> {
     fn to_mut(self) -> &'a mut T {
         match self {
-            Self::Immutable { value, entry } => entry.insert(value.clone()),
+            Self::Immutable { value, entry } => entry.insert(value.into_owned()),
             Self::Mutable { value } => value,
         }
     }
@@ -63,7 +64,7 @@ impl<'a, T: Clone> Deref for BTreeCow<'a, T> {
 
 pub enum VecCow<'a, T: Clone> {
     Immutable {
-        value: &'a T,
+        value: StdCow<'a, T>,
         entry: vec_map::VacantEntry<'a, T>,
     },
     Mutable {
@@ -74,7 +75,7 @@ pub enum VecCow<'a, T: Clone> {
 impl<'a, T: Clone> CowTrait<'a, T> for VecCow<'a, T> {
     fn to_mut(self) -> &'a mut T {
         match self {
-            Self::Immutable { value, entry } => entry.insert(value.clone()),
+            Self::Immutable { value, entry } => entry.insert(value.into_owned()),
             Self::Mutable { value } => value,
         }
     }

--- a/src/interface_iter.rs
+++ b/src/interface_iter.rs
@@ -1,19 +1,19 @@
 use crate::iter::Iter;
-use crate::{Cow, UpdateMap};
-use tree_hash::TreeHash;
+use crate::{Cow, UpdateMap, Value};
+use std::borrow::Cow as StdCow;
 
 #[derive(Debug)]
-pub struct InterfaceIter<'a, T: TreeHash + Clone, U: UpdateMap<T>> {
+pub struct InterfaceIter<'a, T: Value, U: UpdateMap<T>> {
     pub(crate) tree_iter: Iter<'a, T>,
     pub(crate) updates: &'a U,
     pub(crate) index: usize,
     pub(crate) length: usize,
 }
 
-impl<'a, T: TreeHash + Clone, U: UpdateMap<T>> Iterator for InterfaceIter<'a, T, U> {
-    type Item = &'a T;
+impl<'a, T: Value, U: UpdateMap<T>> Iterator for InterfaceIter<'a, T, U> {
+    type Item = StdCow<'a, T>;
 
-    fn next(&mut self) -> Option<&'a T> {
+    fn next(&mut self) -> Option<StdCow<'a, T>> {
         let index = self.index;
         self.index += 1;
 
@@ -30,16 +30,16 @@ impl<'a, T: TreeHash + Clone, U: UpdateMap<T>> Iterator for InterfaceIter<'a, T,
     }
 }
 
-impl<'a, T: TreeHash + Clone, U: UpdateMap<T>> ExactSizeIterator for InterfaceIter<'a, T, U> {}
+impl<'a, T: Value, U: UpdateMap<T>> ExactSizeIterator for InterfaceIter<'a, T, U> {}
 
 #[derive(Debug)]
-pub struct InterfaceIterCow<'a, T: TreeHash + Clone, U: UpdateMap<T>> {
+pub struct InterfaceIterCow<'a, T: Value, U: UpdateMap<T>> {
     pub(crate) tree_iter: Iter<'a, T>,
     pub(crate) updates: &'a mut U,
     pub(crate) index: usize,
 }
 
-impl<'a, T: TreeHash + Clone, U: UpdateMap<T>> InterfaceIterCow<'a, T, U> {
+impl<'a, T: Value, U: UpdateMap<T>> InterfaceIterCow<'a, T, U> {
     pub fn next_cow(&mut self) -> Option<(usize, Cow<T>)> {
         let index = self.index;
         self.index += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,10 @@ pub use tree::Tree;
 pub use triomphe::Arc;
 pub use update_map::UpdateMap;
 pub use vector::Vector;
+
+use ssz::{Decode, Encode};
+use tree_hash::TreeHash;
+
+pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone {}
+
+impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone {}

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,12 +6,13 @@ use crate::iter::Iter;
 use crate::serde::ListVisitor;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, int_log, opt_packing_depth, updated_length, Length};
-use crate::{Arc, Cow, Error, Tree, UpdateMap};
+use crate::{Arc, Cow, Error, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
 use derivative::Derivative;
 use itertools::process_results;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode, SszEncoder, TryFromIter, BYTES_PER_LENGTH_OFFSET};
+use std::borrow::Cow as StdCow;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use tree_hash::{Hash256, PackedEncoding, TreeHash};
@@ -19,19 +20,17 @@ use typenum::Unsigned;
 use vec_map::VecMap;
 
 #[derive(Debug, Clone, Derivative, Arbitrary)]
-#[derivative(PartialEq(
-    bound = "T: TreeHash + PartialEq + Clone, N: Unsigned, U: UpdateMap<T> + PartialEq"
-))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + TreeHash + PartialEq + Clone")]
+#[derivative(PartialEq(bound = "T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq"))]
+#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value")]
 #[arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T> + PartialEq")]
-pub struct List<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
+pub struct List<T: Value, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
     pub(crate) interface: Interface<T, ListInner<T, N>, U>,
 }
 
 #[derive(Debug, Clone, Derivative, Arbitrary)]
-#[derivative(PartialEq(bound = "T: TreeHash + PartialEq + Clone, N: Unsigned"))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + TreeHash + PartialEq + Clone, N: Unsigned")]
-pub struct ListInner<T: TreeHash + Clone, N: Unsigned> {
+#[derivative(PartialEq(bound = "T: Value, N: Unsigned"))]
+#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")]
+pub struct ListInner<T: Value, N: Unsigned> {
     #[arbitrary(with = arb_arc)]
     pub(crate) tree: Arc<Tree<T>>,
     pub(crate) length: Length,
@@ -41,7 +40,7 @@ pub struct ListInner<T: TreeHash + Clone, N: Unsigned> {
     _phantom: PhantomData<N>,
 }
 
-impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     pub fn new(vec: Vec<T>) -> Result<Self, Error> {
         Self::try_from_iter(vec)
     }
@@ -105,7 +104,7 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     }
 
     pub fn to_vec(&self) -> Vec<T> {
-        self.iter().cloned().collect()
+        self.iter().map(|res| res.into_owned()).collect()
     }
 
     pub fn iter(&self) -> InterfaceIter<T, U> {
@@ -128,7 +127,7 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     }
 
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
-    pub fn get(&self, index: usize) -> Option<&T> {
+    pub fn get(&self, index: usize) -> Option<StdCow<T>> {
         self.interface.get(index)
     }
 
@@ -173,8 +172,8 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     }
 }
 
-impl<T: TreeHash + Clone, N: Unsigned> ImmList<T> for ListInner<T, N> {
-    fn get(&self, index: usize) -> Option<&T> {
+impl<T: Value, N: Unsigned> ImmList<T> for ListInner<T, N> {
+    fn get(&self, index: usize) -> Option<StdCow<T>> {
         if index < self.len().as_usize() {
             self.tree
                 .get_recursive(index, self.depth, self.packing_depth)
@@ -194,7 +193,7 @@ impl<T: TreeHash + Clone, N: Unsigned> ImmList<T> for ListInner<T, N> {
 
 impl<T, N> MutList<T> for ListInner<T, N>
 where
-    T: TreeHash + Clone,
+    T: Value,
     N: Unsigned,
 {
     fn validate_push(current_len: usize) -> Result<(), Error> {
@@ -241,9 +240,7 @@ where
     }
 }
 
-impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMap<T>>
-    List<T, N, U>
-{
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     pub fn rebase(&self, base: &Self) -> Result<Self, Error> {
         // Diff self from base.
         let diff = ListDiff::compute_diff(base, self)?;
@@ -262,13 +259,13 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
     }
 }
 
-impl<T: TreeHash + Clone, N: Unsigned> Default for List<T, N> {
+impl<T: Value, N: Unsigned> Default for List<T, N> {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl<T: TreeHash + Clone + Send + Sync, N: Unsigned> TreeHash for List<T, N> {
+impl<T: Value + Send + Sync, N: Unsigned> TreeHash for List<T, N> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::List
     }
@@ -290,8 +287,8 @@ impl<T: TreeHash + Clone + Send + Sync, N: Unsigned> TreeHash for List<T, N> {
     }
 }
 
-impl<'a, T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a List<T, N, U> {
-    type Item = &'a T;
+impl<'a, T: Value, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a List<T, N, U> {
+    type Item = StdCow<'a, T>;
     type IntoIter = InterfaceIter<'a, T, U>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -299,7 +296,7 @@ impl<'a, T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a
     }
 }
 
-impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Serialize for List<T, N, U>
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Serialize for List<T, N, U>
 where
     T: Serialize,
 {
@@ -309,7 +306,7 @@ where
     {
         let mut seq = serializer.serialize_seq(Some(self.len()))?;
         for e in self {
-            seq.serialize_element(e)?;
+            seq.serialize_element(&e)?;
         }
         seq.end()
     }
@@ -317,7 +314,7 @@ where
 
 impl<'de, T, N, U> Deserialize<'de> for List<T, N, U>
 where
-    T: Deserialize<'de> + TreeHash + Clone,
+    T: Deserialize<'de> + Value,
     N: Unsigned,
     U: UpdateMap<T>,
 {
@@ -330,7 +327,7 @@ where
 }
 
 // FIXME: duplicated from `ssz::encode::impl_for_vec`
-impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for List<T, N> {
+impl<T: Value, N: Unsigned> Encode for List<T, N> {
     fn is_ssz_fixed_len() -> bool {
         false
     }
@@ -346,8 +343,8 @@ impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for List<T, N> {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        if T::is_ssz_fixed_len() {
-            buf.reserve(T::ssz_fixed_len() * self.len());
+        if <T as Encode>::is_ssz_fixed_len() {
+            buf.reserve(<T as Encode>::ssz_fixed_len() * self.len());
 
             for item in self {
                 item.ssz_append(buf);
@@ -356,7 +353,7 @@ impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for List<T, N> {
             let mut encoder = SszEncoder::container(buf, self.len() * BYTES_PER_LENGTH_OFFSET);
 
             for item in self {
-                encoder.append(item);
+                encoder.append(&item.into_owned());
             }
 
             encoder.finalize();
@@ -366,7 +363,7 @@ impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for List<T, N> {
 
 impl<T, N> TryFromIter<T> for List<T, N>
 where
-    T: TreeHash + Clone,
+    T: Value,
     N: Unsigned,
 {
     type Error = Error;
@@ -381,7 +378,7 @@ where
 
 impl<T, N> Decode for List<T, N>
 where
-    T: Decode + TreeHash + Clone,
+    T: Value,
     N: Unsigned,
 {
     fn is_ssz_fixed_len() -> bool {
@@ -393,10 +390,10 @@ where
 
         if bytes.is_empty() {
             Ok(List::empty())
-        } else if T::is_ssz_fixed_len() {
+        } else if <T as Decode>::is_ssz_fixed_len() {
             let num_items = bytes
                 .len()
-                .checked_div(T::ssz_fixed_len())
+                .checked_div(<T as Decode>::ssz_fixed_len())
                 .ok_or(ssz::DecodeError::ZeroLengthItem)?;
 
             if num_items > max_len {
@@ -407,7 +404,9 @@ where
             }
 
             process_results(
-                bytes.chunks(T::ssz_fixed_len()).map(T::from_ssz_bytes),
+                bytes
+                    .chunks(<T as Decode>::ssz_fixed_len())
+                    .map(T::from_ssz_bytes),
                 |iter| {
                     List::try_from_iter(iter).map_err(|e| {
                         ssz::DecodeError::BytesInvalid(format!("Error building ssz List: {:?}", e))

--- a/src/packed_leaf.rs
+++ b/src/packed_leaf.rs
@@ -1,132 +1,166 @@
-use crate::{utils::arb_rwlock, Error, UpdateMap};
+use crate::{utils::arb_rwlock, Error, UpdateMap, Value};
 use arbitrary::Arbitrary;
+use core::marker::PhantomData;
 use derivative::Derivative;
 use parking_lot::RwLock;
 use std::ops::ControlFlow;
-use tree_hash::{Hash256, TreeHash, BYTES_PER_CHUNK};
+use tree_hash::{Hash256, BYTES_PER_CHUNK};
 
 #[derive(Debug, Derivative, Arbitrary)]
 #[derivative(PartialEq, Hash)]
-pub struct PackedLeaf<T: TreeHash + Clone> {
+pub struct PackedLeaf<T: Value> {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     #[arbitrary(with = arb_rwlock)]
     pub hash: RwLock<Hash256>,
-    pub(crate) values: Vec<T>,
+    pub length: u8,
+    _phantom: PhantomData<T>,
 }
 
 impl<T> Clone for PackedLeaf<T>
 where
-    T: TreeHash + Clone,
+    T: Value,
 {
     fn clone(&self) -> Self {
         Self {
             hash: RwLock::new(*self.hash.read()),
-            values: self.values.clone(),
+            length: self.length,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T: TreeHash + Clone> PackedLeaf<T> {
+impl<T: Value> PackedLeaf<T> {
+    fn length(&self) -> usize {
+        self.length as usize
+    }
+
+    fn value_len(_value: &T) -> usize {
+        BYTES_PER_CHUNK / T::tree_hash_packing_factor()
+    }
+
+    pub fn values(&self) -> Vec<T> {
+        self.hash
+            .read()
+            .as_bytes()
+            .chunks_exact(BYTES_PER_CHUNK / T::tree_hash_packing_factor())
+            .take(self.length())
+            .map(|bytes| T::from_ssz_bytes(bytes).expect("Should always deserialize"))
+            .collect::<Vec<T>>()
+    }
+
+    pub fn get(&self, index: usize) -> Option<T> {
+        self.values().get(index).cloned()
+    }
+
     pub fn tree_hash(&self) -> Hash256 {
-        let read_lock = self.hash.read();
-        let mut hash = *read_lock;
-        drop(read_lock);
-
-        if !hash.is_zero() {
-            return hash;
-        }
-
-        let hash_bytes = hash.as_bytes_mut();
-
-        let value_len = BYTES_PER_CHUNK / T::tree_hash_packing_factor();
-        for (i, value) in self.values.iter().enumerate() {
-            hash_bytes[i * value_len..(i + 1) * value_len]
-                .copy_from_slice(&value.tree_hash_packed_encoding());
-        }
-
-        *self.hash.write() = hash;
-        hash
+        *self.hash.read()
     }
 
     pub fn empty() -> Self {
         PackedLeaf {
             hash: RwLock::new(Hash256::zero()),
-            values: Vec::with_capacity(T::tree_hash_packing_factor()),
+            length: 0,
+            _phantom: PhantomData,
         }
     }
 
     pub fn single(value: T) -> Self {
-        let mut values = Vec::with_capacity(T::tree_hash_packing_factor());
-        values.push(value);
+        let mut hash = Hash256::zero();
+        let hash_bytes = hash.as_bytes_mut();
+
+        let value_len = Self::value_len(&value);
+        hash_bytes[0..value_len].copy_from_slice(&value.as_ssz_bytes());
 
         PackedLeaf {
-            hash: RwLock::new(Hash256::zero()),
-            values,
+            hash: RwLock::new(hash),
+            length: 1,
+            _phantom: PhantomData,
         }
     }
 
     pub fn repeat(value: T, n: usize) -> Self {
         assert!(n <= T::tree_hash_packing_factor());
+
+        let mut hash = Hash256::zero();
+        let hash_bytes = hash.as_bytes_mut();
+
+        let value_len = Self::value_len(&value);
+
+        for (i, value) in vec![value; n].iter().enumerate() {
+            hash_bytes[i * value_len..(i + 1) * value_len].copy_from_slice(&value.as_ssz_bytes());
+        }
+
         PackedLeaf {
-            hash: RwLock::new(Hash256::zero()),
-            values: vec![value; n],
+            hash: RwLock::new(hash),
+            length: n as u8,
+            _phantom: PhantomData,
         }
     }
 
     pub fn insert_at_index(&self, index: usize, value: T) -> Result<Self, Error> {
-        let mut updated = PackedLeaf {
-            hash: RwLock::new(Hash256::zero()),
-            values: self.values.clone(),
-        };
-        let sub_index = index % T::tree_hash_packing_factor();
-        updated.insert_mut(sub_index, value)?;
+        let mut updated = self.clone();
+
+        updated.insert_mut(index, value)?;
+
         Ok(updated)
     }
 
     pub fn update<U: UpdateMap<T>>(
         &self,
         prefix: usize,
-        hash: Hash256,
+        _hash: Hash256,
         updates: &U,
     ) -> Result<Self, Error> {
-        let mut updated = PackedLeaf {
-            hash: RwLock::new(hash),
-            values: self.values.clone(),
-        };
-
         let packing_factor = T::tree_hash_packing_factor();
         let start = prefix;
         let end = prefix + packing_factor;
+
+        let mut updated = self.clone();
+
         updates.for_each_range(start, end, |index, value| {
             ControlFlow::Continue(updated.insert_mut(index % packing_factor, value.clone()))
         })?;
+
         Ok(updated)
     }
 
-    pub fn insert_mut(&mut self, sub_index: usize, value: T) -> Result<(), Error> {
-        // Ensure hash is 0.
-        *self.hash.get_mut() = Hash256::zero();
+    pub fn insert_mut(&mut self, index: usize, value: T) -> Result<(), Error> {
+        // Convert the index to the index of the underlying bytes.
+        let sub_index = index * Self::value_len(&value);
 
-        if sub_index == self.values.len() {
-            self.values.push(value);
-        } else if sub_index < self.values.len() {
-            self.values[sub_index] = value;
-        } else {
+        if sub_index >= BYTES_PER_CHUNK {
             return Err(Error::PackedLeafOutOfBounds {
                 sub_index,
-                len: self.values.len(),
+                len: self.length(),
             });
         }
+
+        let value_len = Self::value_len(&value);
+
+        let mut hash = *self.hash.read();
+        let hash_bytes = hash.as_bytes_mut();
+
+        hash_bytes[sub_index..sub_index + value_len].copy_from_slice(&value.as_ssz_bytes());
+
+        *self.hash.write() = hash;
+
+        if index == self.length() {
+            self.length += 1;
+        } else if index > self.length() {
+            panic!("This is bad");
+        }
+
         Ok(())
     }
 
     pub fn push(&mut self, value: T) -> Result<(), Error> {
-        if self.values.len() == T::tree_hash_packing_factor() {
-            return Err(Error::PackedLeafFull {
-                len: self.values.len(),
-            });
+        // Ensure a new T will not overflow the leaf.
+        if self.length() >= T::tree_hash_packing_factor() {
+            return Err(Error::PackedLeafFull { len: self.length() });
         }
-        self.values.push(value);
+
+        self.insert_mut(self.length(), value.clone())?;
+
         Ok(())
     }
 }

--- a/src/repeat.rs
+++ b/src/repeat.rs
@@ -1,13 +1,13 @@
 use crate::utils::{opt_packing_factor, Length};
-use crate::{Arc, Error, Leaf, List, PackedLeaf, Tree, UpdateMap};
+use crate::{Arc, Error, Leaf, List, PackedLeaf, Tree, UpdateMap, Value};
 use smallvec::{smallvec, SmallVec};
-use tree_hash::{Hash256, TreeHash};
+use tree_hash::Hash256;
 use typenum::Unsigned;
 
 /// Efficiently construct a list from `n` copies of `elem`.
 pub fn repeat_list<T, N, U>(elem: T, n: usize) -> Result<List<T, N, U>, Error>
 where
-    T: TreeHash + Clone,
+    T: Value,
     N: Unsigned,
     U: UpdateMap<T>,
 {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,7 @@
-use crate::{List, UpdateMap};
+use crate::{List, UpdateMap, Value};
 use itertools::process_results;
 use serde::Deserialize;
 use std::marker::PhantomData;
-use tree_hash::TreeHash;
 use typenum::Unsigned;
 
 pub struct ListVisitor<T, N, U> {
@@ -19,7 +18,7 @@ impl<T, N, U> Default for ListVisitor<T, N, U> {
 
 impl<'a, T, N, U> serde::de::Visitor<'a> for ListVisitor<T, N, U>
 where
-    T: Deserialize<'a> + TreeHash + Clone,
+    T: Deserialize<'a> + Value,
     N: Unsigned,
     U: UpdateMap<T>,
 {

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -17,7 +17,13 @@ fn build_partial_hash256_list() {
         let slow_list = List::<Hash256, N>::try_from_iter_slow(sub_vec.clone()).unwrap();
 
         assert_eq!(fast_list, slow_list);
-        assert_eq!(fast_list.iter().cloned().collect::<Vec<_>>(), sub_vec);
+        assert_eq!(
+            fast_list
+                .iter()
+                .map(|item| item.into_owned())
+                .collect::<Vec<_>>(),
+            sub_vec
+        );
     }
 }
 
@@ -34,6 +40,12 @@ fn build_packed_u64_list() {
         let slow_list = List::<u64, N>::try_from_iter(sub_vec.clone()).unwrap();
 
         assert_eq!(fast_list, slow_list);
-        assert_eq!(fast_list.iter().cloned().collect::<Vec<_>>(), sub_vec);
+        assert_eq!(
+            fast_list
+                .iter()
+                .map(|item| item.into_owned())
+                .collect::<Vec<_>>(),
+            sub_vec
+        );
     }
 }

--- a/src/tests/diff.rs
+++ b/src/tests/diff.rs
@@ -1,4 +1,4 @@
-use crate::{Diff, Error, List, ListDiff};
+use crate::{Diff, Error, List, ListDiff, Value};
 use std::fmt::Debug;
 use tree_hash::TreeHash;
 use typenum::{Unsigned, U16};
@@ -45,7 +45,7 @@ where
 
 fn with_updated_index<T, N>(list: &List<T, N>, index: usize, value: T) -> List<T, N>
 where
-    T: TreeHash + Send + Sync + Clone,
+    T: Value + Send + Sync,
     N: Unsigned,
 {
     let mut updated = list.clone();
@@ -58,7 +58,7 @@ where
 
 fn extended<T, N>(list: &List<T, N>, values: Vec<T>) -> List<T, N>
 where
-    T: TreeHash + Send + Sync + Clone,
+    T: Value + Send + Sync,
     N: Unsigned,
 {
     let mut updated = list.clone();

--- a/src/tests/iterator.rs
+++ b/src/tests/iterator.rs
@@ -9,7 +9,13 @@ fn hash256_vec_iter() {
     let vec = (0..n).map(Hash256::from_low_u64_be).collect::<Vec<_>>();
     let vector = Vector::<Hash256, N>::new(vec.clone()).unwrap();
 
-    assert_eq!(vector.iter().cloned().collect::<Vec<_>>(), vec);
+    assert_eq!(
+        vector
+            .iter()
+            .map(|item| item.into_owned())
+            .collect::<Vec<_>>(),
+        vec
+    );
 }
 
 #[test]
@@ -19,7 +25,12 @@ fn hash256_list_iter() {
     let vec = (0..n).map(Hash256::from_low_u64_be).collect::<Vec<_>>();
     let list = List::<Hash256, N>::new(vec.clone()).unwrap();
 
-    assert_eq!(list.iter().cloned().collect::<Vec<_>>(), vec);
+    assert_eq!(
+        list.iter()
+            .map(|item| item.into_owned())
+            .collect::<Vec<_>>(),
+        vec
+    );
 }
 
 #[test]
@@ -33,7 +44,10 @@ fn hash256_list_iter_from() {
 
     for i in 0..=n {
         assert_eq!(
-            list.iter_from(i).unwrap().cloned().collect::<Vec<_>>(),
+            list.iter_from(i)
+                .unwrap()
+                .map(|item| item.into_owned())
+                .collect::<Vec<_>>(),
             &vec[i..]
         );
     }
@@ -58,7 +72,10 @@ fn hash256_vector_iter_from() {
 
     for i in 0..=n {
         assert_eq!(
-            vect.iter_from(i).unwrap().cloned().collect::<Vec<_>>(),
+            vect.iter_from(i)
+                .unwrap()
+                .map(|item| item.into_owned())
+                .collect::<Vec<_>>(),
             &vec[i..]
         );
     }

--- a/src/tests/packed.rs
+++ b/src/tests/packed.rs
@@ -9,11 +9,11 @@ fn u64_packed_list_build_and_iter() {
         let vec = (0..len).map(|i| 2 * i).collect::<Vec<u64>>();
         let list = List::<u64, U16>::new(vec.clone()).unwrap();
 
-        let from_iter = list.iter().copied().collect::<Vec<_>>();
+        let from_iter = list.iter().map(|res| res.into_owned()).collect::<Vec<_>>();
         assert_eq!(vec, from_iter);
 
         for i in 0..len as usize {
-            assert_eq!(list.get(i), vec.get(i));
+            assert_eq!(list.get(i).map(|res| res.into_owned()).as_ref(), vec.get(i));
         }
     }
 }
@@ -36,11 +36,17 @@ fn u64_packed_vector_build_and_iter() {
     let vec = (0..len).map(|i| 2 * i).collect::<Vec<u64>>();
     let vector = Vector::<u64, U16>::new(vec.clone()).unwrap();
 
-    let from_iter = vector.iter().copied().collect::<Vec<_>>();
+    let from_iter = vector
+        .iter()
+        .map(|res| res.into_owned())
+        .collect::<Vec<_>>();
     assert_eq!(vec, from_iter);
 
     for i in 0..len as usize {
-        assert_eq!(vector.get(i), vec.get(i));
+        assert_eq!(
+            vector.get(i).map(|res| res.into_owned()).as_ref(),
+            vec.get(i)
+        );
     }
 }
 
@@ -74,11 +80,11 @@ fn out_of_order_mutations() {
     for (i, v) in mutations {
         *list.get_mut(i).unwrap() = v;
         vec[i] = v;
-        assert_eq!(list.get(i), Some(&v));
+        assert_eq!(list.get(i).map(|res| res.into_owned()), Some(v));
 
         list.apply_updates().unwrap();
 
-        assert_eq!(list.get(i), Some(&v));
+        assert_eq!(list.get(i).map(|res| res.into_owned()), Some(v));
     }
 
     assert_eq!(list.to_vec(), vec);

--- a/src/tests/repeat.rs
+++ b/src/tests/repeat.rs
@@ -1,9 +1,9 @@
-use crate::List;
+use crate::{List, Value};
 use std::fmt::Debug;
 use tree_hash::TreeHash;
 use typenum::{Unsigned, U1024, U64, U8};
 
-fn list_test<T: TreeHash + PartialEq + Clone + Send + Sync + Debug, N: Unsigned + Debug>(val: T) {
+fn list_test<T: Value + Send + Sync + Debug, N: Unsigned + Debug>(val: T) {
     for n in 96..=N::to_usize() {
         let fast = List::<T, N>::repeat(val.clone(), n).unwrap();
         let slow = List::<T, N>::repeat_slow(val.clone(), n).unwrap();

--- a/src/tests/size_of.rs
+++ b/src/tests/size_of.rs
@@ -6,9 +6,9 @@ use tree_hash::Hash256;
 /// It's important that the Tree nodes have a predictable size.
 #[test]
 fn size_of_hash256() {
-    assert_eq!(size_of::<Tree<Hash256>>(), 72);
+    assert_eq!(size_of::<Tree<Hash256>>(), 64);
     assert_eq!(size_of::<Leaf<Hash256>>(), 48);
-    assert_eq!(size_of::<PackedLeaf<Hash256>>(), 64);
+    assert_eq!(size_of::<PackedLeaf<Hash256>>(), 48);
 
     let rw_lock_size = size_of::<RwLock<Hash256>>();
     assert_eq!(rw_lock_size, 40);
@@ -18,19 +18,19 @@ fn size_of_hash256() {
 
     assert_eq!(
         size_of::<Tree<Hash256>>(),
-        size_of::<PackedLeaf<Hash256>>() + 8
+        size_of::<PackedLeaf<Hash256>>() + 16
     );
 }
 
 /// It's important that the Tree nodes have a predictable size.
 #[test]
 fn size_of_u8() {
-    assert_eq!(size_of::<Tree<u8>>(), 72);
+    assert_eq!(size_of::<Tree<u8>>(), 64);
     assert_eq!(size_of::<Leaf<u8>>(), 48);
-    assert_eq!(size_of::<PackedLeaf<u8>>(), 64);
+    assert_eq!(size_of::<PackedLeaf<u8>>(), 48);
     assert_eq!(
         size_of::<PackedLeaf<u8>>(),
-        size_of::<RwLock<Hash256>>() + size_of::<Vec<u8>>()
+        size_of::<RwLock<Hash256>>() + size_of::<u64>()
     );
 
     let rw_lock_size = size_of::<RwLock<u8>>();
@@ -39,5 +39,5 @@ fn size_of_u8() {
     let arc_size = size_of::<Arc<Tree<u8>>>();
     assert_eq!(arc_size, 8);
 
-    assert_eq!(size_of::<Tree<u8>>(), size_of::<PackedLeaf<u8>>() + 8);
+    assert_eq!(size_of::<Tree<u8>>(), size_of::<PackedLeaf<u8>>() + 16);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,7 +49,7 @@ pub fn max_btree_index<T>(map: &BTreeMap<usize, T>) -> Option<usize> {
 }
 
 /// Compute the length a data structure will have after applying `updates`.
-pub fn updated_length<U: UpdateMap<T>, T>(prev_len: Length, updates: &U) -> Length {
+pub fn updated_length<U: UpdateMap<T>, T: Clone>(prev_len: Length, updates: &U) -> Length {
     updates.max_index().map_or(prev_len, |max_idx| {
         Length(std::cmp::max(max_idx + 1, prev_len.as_usize()))
     })

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -4,38 +4,35 @@ use crate::interface_iter::InterfaceIter;
 use crate::iter::Iter;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, Length};
-use crate::{Arc, Cow, Error, List, Tree, UpdateMap};
+use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode, SszEncoder, TryFromIter, BYTES_PER_LENGTH_OFFSET};
+use std::borrow::Cow as StdCow;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::marker::PhantomData;
-use tree_hash::{Hash256, PackedEncoding, TreeHash};
+use tree_hash::{Hash256, PackedEncoding};
 use typenum::Unsigned;
 use vec_map::VecMap;
 
 #[derive(Debug, Derivative, Clone, Serialize, Deserialize, Arbitrary)]
-#[derivative(PartialEq(
-    bound = "T: TreeHash + Clone + PartialEq, N: Unsigned, U: UpdateMap<T> + PartialEq"
-))]
+#[derivative(PartialEq(bound = "T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq"))]
 #[serde(try_from = "List<T, N, U>")]
 #[serde(into = "List<T, N, U>")]
-#[serde(bound(serialize = "T: TreeHash + Clone + Serialize, N: Unsigned, U: UpdateMap<T>"))]
-#[serde(bound(
-    deserialize = "T: TreeHash + Clone + Deserialize<'de>, N: Unsigned, U: UpdateMap<T>"
-))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + TreeHash + Clone")]
+#[serde(bound(serialize = "T: Value + Serialize, N: Unsigned, U: UpdateMap<T>"))]
+#[serde(bound(deserialize = "T: Value + Deserialize<'de>, N: Unsigned, U: UpdateMap<T>"))]
+#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value")]
 #[arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T>")]
-pub struct Vector<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
+pub struct Vector<T: Value, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
     pub(crate) interface: Interface<T, VectorInner<T, N>, U>,
 }
 
 #[derive(Debug, Derivative, Clone, Arbitrary)]
-#[derivative(PartialEq(bound = "T: TreeHash + Clone + PartialEq, N: Unsigned"))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + TreeHash + Clone, N: Unsigned")]
-pub struct VectorInner<T: TreeHash + Clone, N: Unsigned> {
+#[derivative(PartialEq(bound = "T: Value, N: Unsigned"))]
+#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")]
+pub struct VectorInner<T: Value, N: Unsigned> {
     #[arbitrary(with = arb_arc)]
     pub(crate) tree: Arc<Tree<T>>,
     pub(crate) depth: usize,
@@ -44,7 +41,7 @@ pub struct VectorInner<T: TreeHash + Clone, N: Unsigned> {
     _phantom: PhantomData<N>,
 }
 
-impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     pub fn new(vec: Vec<T>) -> Result<Self, Error> {
         if vec.len() == N::to_usize() {
             Self::try_from(List::new(vec)?)
@@ -65,7 +62,7 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     }
 
     pub fn to_vec(&self) -> Vec<T> {
-        self.iter().cloned().collect()
+        self.iter().map(|res| res.into_owned()).collect()
     }
 
     pub fn iter(&self) -> InterfaceIter<T, U> {
@@ -83,7 +80,7 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     }
 
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
-    pub fn get(&self, index: usize) -> Option<&T> {
+    pub fn get(&self, index: usize) -> Option<StdCow<T>> {
         self.interface.get(index)
     }
 
@@ -112,7 +109,7 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     }
 }
 
-impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> TryFrom<List<T, N, U>> for Vector<T, N, U> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> TryFrom<List<T, N, U>> for Vector<T, N, U> {
     type Error = Error;
 
     fn try_from(list: List<T, N, U>) -> Result<Self, Error> {
@@ -140,9 +137,7 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> TryFrom<List<T, N, U>> f
     }
 }
 
-impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMap<T>>
-    Vector<T, N, U>
-{
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     pub fn rebase(&self, base: &Self) -> Result<Self, Error> {
         // Diff self from base.
         let diff = VectorDiff::compute_diff(base, self)?;
@@ -161,7 +156,7 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
     }
 }
 
-impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> From<Vector<T, N, U>> for List<T, N, U> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> From<Vector<T, N, U>> for List<T, N, U> {
     fn from(vector: Vector<T, N, U>) -> Self {
         List::from_parts(
             vector.interface.backing.tree,
@@ -171,8 +166,8 @@ impl<T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> From<Vector<T, N, U>> fo
     }
 }
 
-impl<T: TreeHash + Clone, N: Unsigned> ImmList<T> for VectorInner<T, N> {
-    fn get(&self, index: usize) -> Option<&T> {
+impl<T: Value, N: Unsigned> ImmList<T> for VectorInner<T, N> {
+    fn get(&self, index: usize) -> Option<StdCow<T>> {
         if index < self.len().as_usize() {
             self.tree
                 .get_recursive(index, self.depth, self.packing_depth)
@@ -192,7 +187,7 @@ impl<T: TreeHash + Clone, N: Unsigned> ImmList<T> for VectorInner<T, N> {
 
 impl<T, N> MutList<T> for VectorInner<T, N>
 where
-    T: TreeHash + Clone,
+    T: Value,
     N: Unsigned,
 {
     fn validate_push(_current_len: usize) -> Result<(), Error> {
@@ -230,7 +225,7 @@ where
     }
 }
 
-impl<T: Default + TreeHash + Clone, N: Unsigned> Default for Vector<T, N> {
+impl<T: Default + Value, N: Unsigned> Default for Vector<T, N> {
     fn default() -> Self {
         Self::from_elem(T::default()).unwrap_or_else(|e| {
             panic!(
@@ -242,7 +237,7 @@ impl<T: Default + TreeHash + Clone, N: Unsigned> Default for Vector<T, N> {
     }
 }
 
-impl<T: TreeHash + Clone + Send + Sync, N: Unsigned> tree_hash::TreeHash for Vector<T, N> {
+impl<T: Value + Send + Sync, N: Unsigned> tree_hash::TreeHash for Vector<T, N> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
     }
@@ -264,7 +259,7 @@ impl<T: TreeHash + Clone + Send + Sync, N: Unsigned> tree_hash::TreeHash for Vec
 
 impl<T, N> TryFromIter<T> for Vector<T, N>
 where
-    T: TreeHash + Clone,
+    T: Value,
     N: Unsigned,
 {
     type Error = Error;
@@ -277,8 +272,8 @@ where
     }
 }
 
-impl<'a, T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a Vector<T, N, U> {
-    type Item = &'a T;
+impl<'a, T: Value, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a Vector<T, N, U> {
+    type Item = StdCow<'a, T>;
     type IntoIter = InterfaceIter<'a, T, U>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -287,14 +282,14 @@ impl<'a, T: TreeHash + Clone, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a
 }
 
 // FIXME: duplicated from `ssz::encode::impl_for_vec`
-impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for Vector<T, N> {
+impl<T: Value, N: Unsigned> Encode for Vector<T, N> {
     fn is_ssz_fixed_len() -> bool {
-        T::is_ssz_fixed_len()
+        <T as Encode>::is_ssz_fixed_len()
     }
 
     fn ssz_fixed_len() -> usize {
         if <Self as ssz::Encode>::is_ssz_fixed_len() {
-            T::ssz_fixed_len() * N::to_usize()
+            <T as Encode>::ssz_fixed_len() * N::to_usize()
         } else {
             BYTES_PER_LENGTH_OFFSET
         }
@@ -311,8 +306,8 @@ impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for Vector<T, N> {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        if T::is_ssz_fixed_len() {
-            buf.reserve(T::ssz_fixed_len() * self.len());
+        if <T as Encode>::is_ssz_fixed_len() {
+            buf.reserve(<T as Encode>::ssz_fixed_len() * self.len());
 
             for item in self.iter() {
                 item.ssz_append(buf);
@@ -321,7 +316,7 @@ impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for Vector<T, N> {
             let mut encoder = SszEncoder::container(buf, self.len() * ssz::BYTES_PER_LENGTH_OFFSET);
 
             for item in self.iter() {
-                encoder.append(item);
+                encoder.append(&item.into_owned());
             }
 
             encoder.finalize();
@@ -329,14 +324,14 @@ impl<T: Encode + TreeHash + Clone, N: Unsigned> Encode for Vector<T, N> {
     }
 }
 
-impl<T: Decode + TreeHash + Clone, N: Unsigned> Decode for Vector<T, N> {
+impl<T: Value, N: Unsigned> Decode for Vector<T, N> {
     fn is_ssz_fixed_len() -> bool {
-        T::is_ssz_fixed_len()
+        <T as Decode>::is_ssz_fixed_len()
     }
 
     fn ssz_fixed_len() -> usize {
         if <Self as ssz::Decode>::is_ssz_fixed_len() {
-            T::ssz_fixed_len() * N::to_usize()
+            <T as Decode>::ssz_fixed_len() * N::to_usize()
         } else {
             ssz::BYTES_PER_LENGTH_OFFSET
         }


### PR DESCRIPTION
Addresses #10

Keeps the `hash` field and computes the `values` field on demand.

Currently a WIP awaiting comparisons to keeping just the `values` field and computing `hash` on demand.

## Additional Info

For some reason there are some clippy errors but applying the fixes results in compilation errors. Not sure what is going on there.