### PR TITLE
Add `Cow::make_mut`

### DIFF
--- a/src/cow.rs
+++ b/src/cow.rs
@@ -19,10 +19,10 @@ impl<'a, T: Clone> Deref for Cow<'a, T> {
 }
 
 impl<'a, T: Clone> Cow<'a, T> {
-    pub fn to_mut(self) -> Result<&'a mut T, Error> {
+    pub fn into_mut(self) -> Result<&'a mut T, Error> {
         match self {
-            Self::BTree(cow) => cow.to_mut(),
-            Self::Vec(cow) => cow.to_mut(),
+            Self::BTree(cow) => cow.into_mut(),
+            Self::Vec(cow) => cow.into_mut(),
         }
     }
 
@@ -35,8 +35,7 @@ impl<'a, T: Clone> Cow<'a, T> {
 }
 
 pub trait CowTrait<'a, T: Clone>: Deref<Target = T> {
-    #[allow(clippy::wrong_self_convention)]
-    fn to_mut(self) -> Result<&'a mut T, Error>;
+    fn into_mut(self) -> Result<&'a mut T, Error>;
 
     fn make_mut(&mut self) -> Result<&mut T, Error>;
 }
@@ -52,7 +51,7 @@ pub enum BTreeCow<'a, T: Clone> {
 }
 
 impl<'a, T: Clone> CowTrait<'a, T> for BTreeCow<'a, T> {
-    fn to_mut(self) -> Result<&'a mut T, Error> {
+    fn into_mut(self) -> Result<&'a mut T, Error> {
         match self {
             Self::Immutable { value, entry } => entry
                 .ok_or(Error::CowMissingEntry)
@@ -100,7 +99,7 @@ pub enum VecCow<'a, T: Clone> {
 }
 
 impl<'a, T: Clone> CowTrait<'a, T> for VecCow<'a, T> {
-    fn to_mut(self) -> Result<&'a mut T, Error> {
+    fn into_mut(self) -> Result<&'a mut T, Error> {
         match self {
             Self::Immutable { value, entry } => entry
                 .ok_or(Error::CowMissingEntry)

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,7 @@ pub enum Error {
     BuilderStackEmptyFinalize,
     BuilderStackLeftover,
     BulkUpdateUnclean,
+    CowMissingEntry,
 }
 
 impl Display for Error {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -171,13 +171,13 @@ mod test {
 
         let c1 = list.get_cow(0).unwrap();
         assert_eq!(*c1, 1);
-        *c1.to_mut().unwrap() = 10;
+        *c1.into_mut().unwrap() = 10;
 
         assert_eq!(*list.get(0).unwrap(), 10);
 
         let c2 = list.get_cow(0).unwrap();
         assert_eq!(*c2, 10);
-        *c2.to_mut().unwrap() = 11;
+        *c2.into_mut().unwrap() = 11;
         assert_eq!(*list.get(0).unwrap(), 11);
 
         assert_eq!(list.iter().cloned().collect::<Vec<_>>(), vec![11, 2, 3]);
@@ -189,7 +189,7 @@ mod test {
 
         let mut iter = list.iter_cow();
         while let Some((index, v)) = iter.next_cow() {
-            *v.to_mut().unwrap() = index as u64;
+            *v.into_mut().unwrap() = index as u64;
         }
 
         assert_eq!(list.to_vec(), vec![0, 1, 2]);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -171,13 +171,13 @@ mod test {
 
         let c1 = list.get_cow(0).unwrap();
         assert_eq!(*c1, 1);
-        *c1.to_mut() = 10;
+        *c1.to_mut().unwrap() = 10;
 
         assert_eq!(*list.get(0).unwrap(), 10);
 
         let c2 = list.get_cow(0).unwrap();
         assert_eq!(*c2, 10);
-        *c2.to_mut() = 11;
+        *c2.to_mut().unwrap() = 11;
         assert_eq!(*list.get(0).unwrap(), 11);
 
         assert_eq!(list.iter().cloned().collect::<Vec<_>>(), vec![11, 2, 3]);
@@ -189,7 +189,7 @@ mod test {
 
         let mut iter = list.iter_cow();
         while let Some((index, v)) = iter.next_cow() {
-            *v.to_mut() = index as u64;
+            *v.to_mut().unwrap() = index as u64;
         }
 
         assert_eq!(list.to_vec(), vec![0, 1, 2]);

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -178,13 +178,15 @@ where
                 assert_eq!(res, spec.set(index, value));
             }
             Op::SetCowWithToMut(index, value) => {
-                let res = list.get_cow(index).map(|cow| *cow.to_mut() = value.clone());
+                let res = list
+                    .get_cow(index)
+                    .map(|cow| *cow.to_mut().unwrap() = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
             Op::SetCowWithMakeMut(index, value) => {
                 let res = list
                     .get_cow(index)
-                    .map(|mut cow| *cow.make_mut() = value.clone());
+                    .map(|mut cow| *cow.make_mut().unwrap() = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
             Op::Push(value) => {
@@ -261,13 +263,15 @@ where
                 assert_eq!(res, spec.set(index, value));
             }
             Op::SetCowWithToMut(index, value) => {
-                let res = vect.get_cow(index).map(|cow| *cow.to_mut() = value.clone());
+                let res = vect
+                    .get_cow(index)
+                    .map(|cow| *cow.to_mut().unwrap() = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
             Op::SetCowWithMakeMut(index, value) => {
                 let res = vect
                     .get_cow(index)
-                    .map(|mut cow| *cow.make_mut() = value.clone());
+                    .map(|mut cow| *cow.make_mut().unwrap() = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
             Op::Push(_) => {

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -87,8 +87,8 @@ pub enum Op<T> {
     Get(usize),
     /// Use `get_mut` to set an element at a given index.
     Set(usize, T),
-    /// Use `get_cow` and `to_mut` to set an element at a given index.
-    SetCowWithToMut(usize, T),
+    /// Use `get_cow` and `into_mut` to set an element at a given index.
+    SetCowWithIntoMut(usize, T),
     /// Use `get_cow` and `make_mut` to set an element at a given index.
     SetCowWithMakeMut(usize, T),
     /// Use `push` to try to add a new element to the list.
@@ -125,7 +125,7 @@ where
         Just(Op::Len),
         arb_index(n).prop_map(Op::Get),
         (arb_index(n), strategy).prop_map(|(index, value)| Op::Set(index, value)),
-        (arb_index(n), strategy).prop_map(|(index, value)| Op::SetCowWithToMut(index, value)),
+        (arb_index(n), strategy).prop_map(|(index, value)| Op::SetCowWithIntoMut(index, value)),
         (arb_index(n), strategy).prop_map(|(index, value)| Op::SetCowWithMakeMut(index, value)),
         strategy.prop_map(Op::Push),
         Just(Op::Iter),
@@ -177,10 +177,10 @@ where
                 let res = list.get_mut(index).map(|elem| *elem = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
-            Op::SetCowWithToMut(index, value) => {
+            Op::SetCowWithIntoMut(index, value) => {
                 let res = list
                     .get_cow(index)
-                    .map(|cow| *cow.to_mut().unwrap() = value.clone());
+                    .map(|cow| *cow.into_mut().unwrap() = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
             Op::SetCowWithMakeMut(index, value) => {
@@ -262,10 +262,10 @@ where
                 let res = vect.get_mut(index).map(|elem| *elem = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
-            Op::SetCowWithToMut(index, value) => {
+            Op::SetCowWithIntoMut(index, value) => {
                 let res = vect
                     .get_cow(index)
-                    .map(|cow| *cow.to_mut().unwrap() = value.clone());
+                    .map(|cow| *cow.into_mut().unwrap() = value.clone());
                 assert_eq!(res, spec.set(index, value));
             }
             Op::SetCowWithMakeMut(index, value) => {

--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -61,7 +61,10 @@ impl<T: Clone> UpdateMap<T> for BTreeMap<usize, T> {
         let cow = match self.entry(idx) {
             Entry::Vacant(entry) => {
                 let value = f(idx)?;
-                BTreeCow::Immutable { value, entry }
+                BTreeCow::Immutable {
+                    value,
+                    entry: Some(entry),
+                }
             }
             Entry::Occupied(entry) => BTreeCow::Mutable {
                 value: entry.into_mut(),
@@ -122,7 +125,10 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
         let cow = match self.entry(idx) {
             vec_map::Entry::Vacant(entry) => {
                 let value = f(idx)?;
-                VecCow::Immutable { value, entry }
+                VecCow::Immutable {
+                    value,
+                    entry: Some(entry),
+                }
             }
             vec_map::Entry::Occupied(entry) => VecCow::Mutable {
                 value: entry.into_mut(),


### PR DESCRIPTION
It is useful to be able to upgrade a `Cow` pointer into its mutable variant without consuming it, which is what `Cow::to_mut` does. This PR adds a new method `Cow::make_mut` which makes the Cow pointer mutable, and returns it. The returned reference has a shorter lifetime than the one returned by `to_mut` because it borrows from `&mut self` rather than `self`.

The `to_mut` method has been renamed `into_mut` as we needed to change its type signature anyway to introduce a `Result` type. The new `make_mut` also returns a `Result`.