### PR TITLE
Fast rebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ ethereum-types = { version = "0.14.1", features = ["arbitrary"] }
 ssz_types = "0.5.0"
 proptest = "1.0.0"
 tree_hash_derive = "0.5.0"
+criterion = "0.3"
+
+[[bench]]
+name = "rebase"
+harness = false

--- a/benches/rebase.rs
+++ b/benches/rebase.rs
@@ -1,17 +1,12 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use milhouse::List;
-use ssz::{Decode, Encode};
-use tree_hash::TreeHash;
+use milhouse::{List, Value};
 use typenum::Unsigned;
 
 type C = typenum::U1099511627776;
 const N: u64 = 800_000;
 
 #[inline]
-fn rebase<T: Encode + Decode + TreeHash + PartialEq + Clone, N: Unsigned>(
-    l1: &List<T, N>,
-    l2: &List<T, N>,
-) -> List<T, N> {
+fn rebase<T: Value, N: Unsigned>(l1: &List<T, N>, l2: &List<T, N>) -> List<T, N> {
     let mut l1_rebased = l1.clone();
     l1_rebased.rebase_on(l2).unwrap();
     l1_rebased

--- a/benches/rebase.rs
+++ b/benches/rebase.rs
@@ -1,0 +1,60 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use milhouse::List;
+use ssz::{Decode, Encode};
+use tree_hash::TreeHash;
+use typenum::Unsigned;
+
+type C = typenum::U1099511627776;
+const N: u64 = 800_000;
+
+#[inline]
+fn rebase<T: Encode + Decode + TreeHash + PartialEq + Clone, N: Unsigned>(
+    l1: &List<T, N>,
+    l2: &List<T, N>,
+) -> List<T, N> {
+    let mut l1_rebased = l1.clone();
+    l1_rebased.rebase_on(l2).unwrap();
+    l1_rebased
+}
+
+pub fn rebase_list(c: &mut Criterion) {
+    let size = N;
+
+    let base_list = List::<u64, C>::try_from_iter(0..size).unwrap();
+    let identical = List::<u64, C>::try_from_iter(0..size).unwrap();
+    let push_1_back = List::<u64, C>::try_from_iter(0..=size).unwrap();
+    let mutate_0 = List::<u64, C>::try_from_iter(std::iter::once(2048).chain(1..size)).unwrap();
+    let completely_different = List::<u64, C>::try_from_iter((0..size).rev()).unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new("rebase_identical", size),
+        &(identical.clone(), base_list.clone()),
+        |b, &(ref l1, ref l2)| {
+            b.iter(|| rebase(l1, l2));
+        },
+    );
+    c.bench_with_input(
+        BenchmarkId::new("rebase_push_1_back", size),
+        &(push_1_back.clone(), base_list.clone()),
+        |b, &(ref l1, ref l2)| {
+            b.iter(|| rebase(l1, l2));
+        },
+    );
+    c.bench_with_input(
+        BenchmarkId::new("rebase_mutate0", size),
+        &(mutate_0.clone(), base_list.clone()),
+        |b, &(ref l1, ref l2)| {
+            b.iter(|| rebase(l1, l2));
+        },
+    );
+    c.bench_with_input(
+        BenchmarkId::new("rebase_completely_different", size),
+        &(completely_different.clone(), base_list.clone()),
+        |b, &(ref l1, ref l2)| {
+            b.iter(|| rebase(l1, l2));
+        },
+    );
+}
+
+criterion_group!(benches, rebase_list);
+criterion_main!(benches);

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     InvalidDiffLeaf,
     InvalidDiffNode,
     InvalidDiffPendingUpdates,
+    InvalidRebaseNode,
+    InvalidRebaseLeaf,
     AddToDiffError,
     BuilderExpectedLeaf,
     BuilderStackEmptyMerge,

--- a/src/list.rs
+++ b/src/list.rs
@@ -252,7 +252,12 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
     }
 
     pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
-        match Tree::rebase_on(&self.interface.backing.tree, &base.interface.backing.tree)? {
+        match Tree::rebase_on(
+            &self.interface.backing.tree,
+            &base.interface.backing.tree,
+            Some((self.interface.backing.length, base.interface.backing.length)),
+            self.interface.backing.depth + self.interface.backing.packing_depth,
+        )? {
             RebaseAction::EqualReplace(replacement) => {
                 self.interface.backing.tree = replacement.clone();
             }

--- a/src/list.rs
+++ b/src/list.rs
@@ -4,6 +4,7 @@ use crate::interface::{ImmList, Interface, MutList};
 use crate::interface_iter::{InterfaceIter, InterfaceIterCow};
 use crate::iter::Iter;
 use crate::serde::ListVisitor;
+use crate::tree::RebaseAction;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, int_log, opt_packing_depth, updated_length, Length};
 use crate::{Arc, Cow, Error, Tree, UpdateMap};
@@ -245,6 +246,25 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
     List<T, N, U>
 {
     pub fn rebase(&self, base: &Self) -> Result<Self, Error> {
+        let mut rebased = self.clone();
+        rebased.rebase_on(base)?;
+        Ok(rebased)
+    }
+
+    pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
+        match Tree::rebase_on(&self.interface.backing.tree, &base.interface.backing.tree)? {
+            RebaseAction::EqualReplace(replacement) => {
+                self.interface.backing.tree = replacement.clone();
+            }
+            RebaseAction::NotEqualReplace(replacement) => {
+                self.interface.backing.tree = replacement;
+            }
+            _ => (),
+        }
+        Ok(())
+    }
+
+    pub fn rebase_via_diff(&self, base: &Self) -> Result<Self, Error> {
         // Diff self from base.
         let diff = ListDiff::compute_diff(base, self)?;
 
@@ -253,12 +273,6 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
         diff.apply_diff(&mut new)?;
 
         Ok(new)
-    }
-
-    pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
-        let rebased = self.rebase(base)?;
-        *self = rebased;
-        Ok(())
     }
 }
 

--- a/src/tests/proptest/mod.rs
+++ b/src/tests/proptest/mod.rs
@@ -6,6 +6,7 @@ use tree_hash_derive::TreeHash;
 use typenum::{Unsigned, U4};
 
 mod operations;
+mod rebase;
 mod tree_hash_and_ssz;
 
 pub fn arb_index(n: usize) -> impl Strategy<Value = usize> {

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use tree_hash::{Hash256, TreeHash};
 use typenum::{Unsigned, U1, U1024, U2, U3, U32, U33, U4, U7, U8, U9};
 
-const OP_LIMIT: usize = 32;
+const OP_LIMIT: usize = 128;
 
 /// Simple specification for `List` and `Vector` behaviour.
 #[derive(Debug, Clone)]

--- a/src/tests/proptest/rebase.rs
+++ b/src/tests/proptest/rebase.rs
@@ -1,0 +1,145 @@
+use super::{arb_hash256, arb_large, arb_list, arb_vect, Large};
+use crate::{List, Vector};
+use proptest::prelude::*;
+use tree_hash::Hash256;
+use typenum::{U1, U1024, U2, U3, U32, U33, U4, U7, U8, U9};
+
+macro_rules! list_test {
+    ($name:ident, $T:ty, $N:ty) => {
+        // Use default strategy (assumes existence of an `Arbitrary` impl).
+        list_test!($name, $T, $N, any::<$T>());
+    };
+    ($name:ident, $T:ty, $N:ty, $strat:expr) => {
+        proptest! {
+            #[test]
+            fn $name(
+                orig_vec in arb_list::<$T, $N, _>(&$strat),
+                base_vec in arb_list::<$T, $N, _>(&$strat),
+            ) {
+                let orig = List::<$T, $N>::new(orig_vec).unwrap();
+                let base = List::<$T, $N>::new(base_vec).unwrap();
+                let mut rebased = orig.clone();
+                rebased.rebase_on(&base).unwrap();
+                assert_eq!(rebased, orig);
+            }
+        }
+    };
+}
+
+macro_rules! vect_test {
+    ($name:ident, $T:ty, $N:ty) => {
+        // Use default strategy (assumes existence of an `Arbitrary` impl).
+        vect_test!($name, $T, $N, any::<$T>());
+    };
+    ($name:ident, $T:ty, $N:ty, $strat:expr) => {
+        proptest! {
+            #[test]
+            fn $name(
+                orig_vec in arb_vect::<$T, $N, _>(&$strat),
+                base_vec in arb_vect::<$T, $N, _>(&$strat)
+            ) {
+                let orig = Vector::<$T, $N>::new(orig_vec).unwrap();
+                let base = Vector::<$T, $N>::new(base_vec).unwrap();
+                let mut rebased = orig.clone();
+                rebased.rebase_on(&base).unwrap();
+                assert_eq!(rebased, orig);
+            }
+        }
+    };
+}
+
+mod list {
+    use super::*;
+
+    list_test!(u8_1, u8, U1);
+    list_test!(u8_2, u8, U2);
+    list_test!(u8_3, u8, U3);
+    list_test!(u8_4, u8, U4);
+    list_test!(u8_7, u8, U7);
+    list_test!(u8_8, u8, U8);
+    list_test!(u8_9, u8, U9);
+    list_test!(u8_32, u8, U32);
+    list_test!(u8_33, u8, U33);
+    list_test!(u8_1024, u8, U1024);
+
+    list_test!(u64_1, u64, U1);
+    list_test!(u64_2, u64, U2);
+    list_test!(u64_3, u64, U3);
+    list_test!(u64_4, u64, U4);
+    list_test!(u64_7, u64, U7);
+    list_test!(u64_8, u64, U8);
+    list_test!(u64_9, u64, U9);
+    list_test!(u64_32, u64, U32);
+    list_test!(u64_33, u64, U33);
+    list_test!(u64_1024, u64, U1024);
+
+    list_test!(hash256_1, Hash256, U1, arb_hash256());
+    list_test!(hash256_2, Hash256, U2, arb_hash256());
+    list_test!(hash256_3, Hash256, U3, arb_hash256());
+    list_test!(hash256_4, Hash256, U4, arb_hash256());
+    list_test!(hash256_7, Hash256, U7, arb_hash256());
+    list_test!(hash256_8, Hash256, U8, arb_hash256());
+    list_test!(hash256_9, Hash256, U9, arb_hash256());
+    list_test!(hash256_32, Hash256, U32, arb_hash256());
+    list_test!(hash256_33, Hash256, U33, arb_hash256());
+    list_test!(hash256_1024, Hash256, U1024, arb_hash256());
+
+    list_test!(large_1, Large, U1, arb_large());
+    list_test!(large_2, Large, U2, arb_large());
+    list_test!(large_3, Large, U3, arb_large());
+    list_test!(large_4, Large, U4, arb_large());
+    list_test!(large_7, Large, U7, arb_large());
+    list_test!(large_8, Large, U8, arb_large());
+    list_test!(large_9, Large, U9, arb_large());
+    list_test!(large_32, Large, U32, arb_large());
+    list_test!(large_33, Large, U33, arb_large());
+    list_test!(large_1024, Large, U1024, arb_large());
+}
+
+mod vect {
+    use super::*;
+
+    vect_test!(u8_1, u8, U1);
+    vect_test!(u8_2, u8, U2);
+    vect_test!(u8_3, u8, U3);
+    vect_test!(u8_4, u8, U4);
+    vect_test!(u8_7, u8, U7);
+    vect_test!(u8_8, u8, U8);
+    vect_test!(u8_9, u8, U9);
+    vect_test!(u8_32, u8, U32);
+    vect_test!(u8_33, u8, U33);
+    vect_test!(u8_1024, u8, U1024);
+
+    vect_test!(u64_1, u64, U1);
+    vect_test!(u64_2, u64, U2);
+    vect_test!(u64_3, u64, U3);
+    vect_test!(u64_4, u64, U4);
+    vect_test!(u64_7, u64, U7);
+    vect_test!(u64_8, u64, U8);
+    vect_test!(u64_9, u64, U9);
+    vect_test!(u64_32, u64, U32);
+    vect_test!(u64_33, u64, U33);
+    vect_test!(u64_1024, u64, U1024);
+
+    vect_test!(hash256_1, Hash256, U1, arb_hash256());
+    vect_test!(hash256_2, Hash256, U2, arb_hash256());
+    vect_test!(hash256_3, Hash256, U3, arb_hash256());
+    vect_test!(hash256_4, Hash256, U4, arb_hash256());
+    vect_test!(hash256_7, Hash256, U7, arb_hash256());
+    vect_test!(hash256_8, Hash256, U8, arb_hash256());
+    vect_test!(hash256_9, Hash256, U9, arb_hash256());
+    vect_test!(hash256_32, Hash256, U32, arb_hash256());
+    vect_test!(hash256_33, Hash256, U33, arb_hash256());
+    vect_test!(hash256_1024, Hash256, U1024, arb_hash256());
+
+    vect_test!(large_1, Large, U1, arb_large());
+    vect_test!(large_2, Large, U2, arb_large());
+    vect_test!(large_3, Large, U3, arb_large());
+    vect_test!(large_4, Large, U4, arb_large());
+    vect_test!(large_7, Large, U7, arb_large());
+    vect_test!(large_8, Large, U8, arb_large());
+    vect_test!(large_9, Large, U9, arb_large());
+    vect_test!(large_32, Large, U32, arb_large());
+    vect_test!(large_33, Large, U33, arb_large());
+    vect_test!(large_1024, Large, U1024, arb_large());
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -413,7 +413,7 @@ impl<T: PartialEq + TreeHash + Clone + Encode + Decode> Tree<T> {
                     left: ref l2,
                     right: ref r2,
                 },
-            ) => {
+            ) if full_depth > 0 => {
                 use RebaseAction::*;
 
                 let orig_hash = *orig_hash_lock.read();
@@ -511,10 +511,10 @@ impl<T: PartialEq + TreeHash + Clone + Encode + Decode> Tree<T> {
                     }
                 }
             }
-            (Self::Zero(_), _) => Ok(RebaseAction::NotEqualNoop),
-            (_, Self::Zero(_)) => Ok(RebaseAction::NotEqualNoop),
+            (Self::Zero(_), _) | (_, Self::Zero(_)) => Ok(RebaseAction::NotEqualNoop),
+            (Self::Node { .. }, Self::Node { .. }) => Err(Error::InvalidRebaseNode),
             (Self::Leaf(_) | Self::PackedLeaf(_), _) | (_, Self::Leaf(_) | Self::PackedLeaf(_)) => {
-                Err(Error::InvalidDiffLeaf)
+                Err(Error::InvalidRebaseLeaf)
             }
         }
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -151,7 +151,12 @@ impl<T: TreeHash + PartialEq + Clone + Decode + Encode, N: Unsigned, U: UpdateMa
     }
 
     pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
-        match Tree::rebase_on(&self.interface.backing.tree, &base.interface.backing.tree)? {
+        match Tree::rebase_on(
+            &self.interface.backing.tree,
+            &base.interface.backing.tree,
+            None,
+            self.interface.backing.depth + self.interface.backing.packing_depth,
+        )? {
             RebaseAction::EqualReplace(replacement) => {
                 self.interface.backing.tree = replacement.clone();
             }


### PR DESCRIPTION
This PR implements a specialised `rebase_on` rather than using diffs to rebase. It is between 5-45x faster than the diff approach according to benchmarks.

It tries harder _not_ to recurse unnecessarily, by checking subtree equality using the hash _and_ the length. The length is required because packed leaves of different lengths can have the same hash due to 0 padding (e.g. we can't differentiate between 3x `0u64` and 4x `0xu64`).

It's also faster because it avoids intermediate allocations for the diff (a bunch of btree nodes).