### PR TITLE
Add new benchmark for SSZ encoding and decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ harness = false
 [[bench]]
 name = "tree_hash_root"
 harness = false
+
+[[bench]]
+name = "ssz"
+harness = false

--- a/benches/ssz.rs
+++ b/benches/ssz.rs
@@ -1,0 +1,104 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use milhouse::{List, Value, Vector};
+use ssz::{Decode, Encode};
+use ssz_types::VariableList;
+use typenum::Unsigned;
+
+type C = typenum::U1099511627776;
+type D = typenum::U1000000;
+const N: u64 = 1_000_000;
+
+#[inline]
+fn encode_list<T: Value, N: Unsigned>(l1: &List<T, N>) -> Vec<u8> {
+    l1.as_ssz_bytes()
+}
+
+#[inline]
+fn encode_decode_list<T: Value, N: Unsigned>(l1: &List<T, N>) -> List<T, N> {
+    let bytes = l1.as_ssz_bytes();
+    let l2 = List::from_ssz_bytes(&bytes).unwrap();
+    l2
+}
+
+#[inline]
+fn encode_vector<T: Value, N: Unsigned>(v1: &Vector<T, N>) -> Vec<u8> {
+    v1.as_ssz_bytes()
+}
+
+#[inline]
+fn encode_decode_vector<T: Value, N: Unsigned>(v1: &Vector<T, N>) -> Vector<T, N> {
+    let bytes = v1.as_ssz_bytes();
+    let v2 = Vector::from_ssz_bytes(&bytes).unwrap();
+    v2
+}
+
+#[inline]
+fn encode_variable_list<T: Value, N: Unsigned>(l1: &VariableList<T, N>) -> Vec<u8> {
+    l1.as_ssz_bytes()
+}
+
+#[inline]
+fn encode_decode_variable_list<T: Value, N: Unsigned>(
+    l1: &VariableList<T, N>,
+) -> VariableList<T, N> {
+    let bytes = l1.as_ssz_bytes();
+    let l2 = VariableList::from_ssz_bytes(&bytes).unwrap();
+    l2
+}
+
+pub fn ssz(c: &mut Criterion) {
+    let size = N;
+
+    let list = List::<u64, C>::try_from_iter(0..size).unwrap();
+    let vector = Vector::<u64, D>::try_from_iter(0..size).unwrap();
+    let variable_list = VariableList::<u64, C>::new((0..size).collect()).unwrap();
+
+    c.bench_with_input(BenchmarkId::new("ssz_encode_list", size), &list, |b, l1| {
+        b.iter(|| encode_list(&l1));
+    });
+
+    c.bench_with_input(
+        BenchmarkId::new("ssz_encode_decode_list", size),
+        &list,
+        |b, l1| {
+            b.iter(|| encode_decode_list(&l1));
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("ssz_encode_vector", size),
+        &vector,
+        |b, v1| {
+            b.iter(|| encode_vector(&v1));
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("ssz_encode_decode_vector", size),
+        &vector,
+        |b, v1| {
+            b.iter(|| encode_decode_vector(&v1));
+        },
+    );
+
+    // Test `VariableList` as a point of comparison.
+    c.bench_with_input(
+        BenchmarkId::new("ssz_encode_variable_list", size),
+        &variable_list,
+        |b, l1| {
+            b.iter(|| encode_variable_list(&l1));
+        },
+    );
+
+    // Test `VariableList` as a point of comparison.
+    c.bench_with_input(
+        BenchmarkId::new("ssz_encode_decode_variable_list", size),
+        &variable_list,
+        |b, l1| {
+            b.iter(|| encode_decode_variable_list(&l1));
+        },
+    );
+}
+
+criterion_group!(benches, ssz);
+criterion_main!(benches);

--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -34,7 +34,7 @@ pub fn tree_hash_root(c: &mut Criterion) {
 
     // Test `VariableList` as a point of comparison.
     c.bench_with_input(
-        BenchmarkId::new("tree_hash_root_ssz_types_list", size),
+        BenchmarkId::new("tree_hash_root_variable_list", size),
         &size,
         |b, &size| {
             b.iter(|| {


### PR DESCRIPTION
## Proposed changes

Add a new benchmark which tests the SSZ encoding and decoding performance of `List` and `Vector` and compares it to `ssz_types::VariableList`.

There are benchmarks for just encoding and then more benchmarks for encoding + decoding. This was done to separate out the two distinct tasks although there might be a neater way to do this.