### PR TITLE
Add parallel tree hashing benchmark

### DIFF
--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -54,12 +54,15 @@ pub fn tree_hash_root(c: &mut Criterion) {
                 l2.push(99).unwrap();
                 l2.apply_updates().unwrap();
 
-                let handle = std::thread::spawn(move || {
+                let handle_1 = std::thread::spawn(move || {
                     l1.tree_hash_root();
+                });
+                let handle_2 = std::thread::spawn(move || {
                     l2.tree_hash_root();
                 });
 
-                handle.join().unwrap();
+                handle_1.join().unwrap();
+                handle_2.join().unwrap();
             });
         },
     );

--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -43,6 +43,26 @@ pub fn tree_hash_root(c: &mut Criterion) {
             })
         },
     );
+
+    c.bench_with_input(
+        BenchmarkId::new("tree_hash_root_list_parallel", size),
+        &size,
+        |b, &size| {
+            b.iter(|| {
+                let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
+                let mut l2 = List::<u64, C>::try_from_iter(0..size).unwrap();
+                l2.push(99).unwrap();
+                l2.apply_updates().unwrap();
+
+                let handle = std::thread::spawn(move || {
+                    l1.tree_hash_root();
+                    l2.tree_hash_root();
+                });
+
+                handle.join().unwrap();
+            });
+        },
+    );
 }
 
 criterion_group!(benches, tree_hash_root);

--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -50,7 +50,7 @@ pub fn tree_hash_root(c: &mut Criterion) {
         |b, &size| {
             b.iter(|| {
                 let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
-                let mut l2 = List::<u64, C>::try_from_iter(0..size).unwrap();
+                let mut l2 = l1.clone();
                 l2.push(99).unwrap();
                 l2.apply_updates().unwrap();
 


### PR DESCRIPTION
## Suggested Changes

Add a benchmark which tree hashes two lists in parallel. This will will allow us to see improvements/regressions relating especially to `RwLock` performance.