### PR TITLE
[Do not merge] Benchmark Tokio executor vs Rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ vec_map = "0.8.2"
 smallvec = "1.8.0"
 arbitrary = { version = "1.2.3", features = ["derive"] }
 ethereum-types = { version = "0.14.1", features = ["arbitrary"] }
-tokio = { version = "1", features = ["sync", "rt"] }
+tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread"] }
 futures = "0.3.29"
 async-recursion = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ vec_map = "0.8.2"
 smallvec = "1.8.0"
 arbitrary = { version = "1.2.3", features = ["derive"] }
 ethereum-types = { version = "0.14.1", features = ["arbitrary"] }
+tokio = { version = "1", features = ["sync", "rt"] }
+futures = "0.3.29"
+async-recursion = "1.0.0"
 
 [dev-dependencies]
 ssz_types = "0.5.0"

--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use milhouse::{List, Vector};
 use ssz_types::VariableList;
+use tokio::runtime::Runtime;
 use tree_hash::TreeHash;
 
 type C = typenum::U1099511627776;
@@ -17,6 +18,18 @@ pub fn tree_hash_root(c: &mut Criterion) {
             b.iter(|| {
                 let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
                 l1.tree_hash_root()
+            });
+        },
+    );
+
+    let rt = Runtime::new().unwrap();
+    c.bench_with_input(
+        BenchmarkId::new("async_tree_hash_root_list", size),
+        &(&rt, size),
+        |b, &(rt, size)| {
+            b.iter(|| {
+                let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
+                rt.block_on(l1.async_tree_hash_root())
             });
         },
     );

--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use milhouse::{List, Vector};
 use ssz_types::VariableList;
-use tokio::runtime::Runtime;
+use tokio::runtime::Builder;
 use tree_hash::TreeHash;
 
 type C = typenum::U1099511627776;
@@ -22,7 +22,12 @@ pub fn tree_hash_root(c: &mut Criterion) {
         },
     );
 
-    let rt = Runtime::new().unwrap();
+    // Tweaking the intervals doesn't really make much difference (a few percent).
+    let rt = Builder::new_multi_thread()
+        .global_queue_interval(1_000_000)
+        .event_interval(1_000_000)
+        .build()
+        .unwrap();
     c.bench_with_input(
         BenchmarkId::new("async_tree_hash_root_list", size),
         &(&rt, size),

--- a/src/leaf.rs
+++ b/src/leaf.rs
@@ -17,19 +17,6 @@ pub struct Leaf<T> {
     pub value: Arc<T>,
 }
 
-impl<T> Clone for Leaf<T>
-where
-    T: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            // FIXME(sproul): this is really annoying
-            hash: RwLock::new(Hash256::zero()),
-            value: self.value.clone(),
-        }
-    }
-}
-
 impl<T> Leaf<T> {
     pub fn new(value: T) -> Self {
         Self::with_hash(value, Hash256::zero())

--- a/src/leaf.rs
+++ b/src/leaf.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use arbitrary::Arbitrary;
 use derivative::Derivative;
-use parking_lot::RwLock;
+use tokio::sync::RwLock;
 use tree_hash::Hash256;
 
 #[derive(Debug, Derivative, Arbitrary)]
@@ -23,7 +23,8 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            hash: RwLock::new(*self.hash.read()),
+            // FIXME(sproul): this is really annoying
+            hash: RwLock::new(Hash256::zero()),
             value: self.value.clone(),
         }
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -293,6 +293,16 @@ impl<T: Value + Send + Sync + 'static, N: Unsigned> TreeHash for List<T, N> {
     }
 }
 
+impl<T: Value + Send + Sync + 'static, N: Unsigned> List<T, N> {
+    pub async fn async_tree_hash_root(&self) -> Hash256 {
+        // FIXME(sproul): remove assert
+        assert!(!self.interface.has_pending_updates());
+
+        let root = self.interface.backing.tree.async_tree_hash().await;
+        tree_hash::mix_in_length(&root, self.len())
+    }
+}
+
 impl<'a, T: Value, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a List<T, N, U> {
     type Item = &'a T;
     type IntoIter = InterfaceIter<'a, T, U>;

--- a/src/list.rs
+++ b/src/list.rs
@@ -271,7 +271,7 @@ impl<T: Value, N: Unsigned> Default for List<T, N> {
     }
 }
 
-impl<T: Value + Send + Sync, N: Unsigned> TreeHash for List<T, N> {
+impl<T: Value + Send + Sync + 'static, N: Unsigned> TreeHash for List<T, N> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::List
     }

--- a/src/packed_leaf.rs
+++ b/src/packed_leaf.rs
@@ -14,19 +14,6 @@ pub struct PackedLeaf<T: TreeHash + Clone> {
     pub(crate) values: Vec<T>,
 }
 
-impl<T> Clone for PackedLeaf<T>
-where
-    T: TreeHash + Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            // FIXME(sproul): perf implications of this might be bad
-            hash: RwLock::new(Hash256::zero()),
-            values: self.values.clone(),
-        }
-    }
-}
-
 impl<T: TreeHash + Clone> PackedLeaf<T> {
     pub fn tree_hash(&self) -> Hash256 {
         let read_lock = self.hash.blocking_read();

--- a/src/packed_leaf.rs
+++ b/src/packed_leaf.rs
@@ -1,8 +1,8 @@
 use crate::{utils::arb_rwlock, Error, UpdateMap};
 use arbitrary::Arbitrary;
 use derivative::Derivative;
-use parking_lot::RwLock;
 use std::ops::ControlFlow;
+use tokio::sync::RwLock;
 use tree_hash::{Hash256, TreeHash, BYTES_PER_CHUNK};
 
 #[derive(Debug, Derivative, Arbitrary)]
@@ -20,7 +20,8 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            hash: RwLock::new(*self.hash.read()),
+            // FIXME(sproul): perf implications of this might be bad
+            hash: RwLock::new(Hash256::zero()),
             values: self.values.clone(),
         }
     }
@@ -28,7 +29,7 @@ where
 
 impl<T: TreeHash + Clone> PackedLeaf<T> {
     pub fn tree_hash(&self) -> Hash256 {
-        let read_lock = self.hash.read();
+        let read_lock = self.hash.blocking_read();
         let mut hash = *read_lock;
         drop(read_lock);
 
@@ -44,7 +45,28 @@ impl<T: TreeHash + Clone> PackedLeaf<T> {
                 .copy_from_slice(&value.tree_hash_packed_encoding());
         }
 
-        *self.hash.write() = hash;
+        *self.hash.blocking_write() = hash;
+        hash
+    }
+
+    pub async fn async_tree_hash(&self) -> Hash256 {
+        let read_lock = self.hash.read().await;
+        let mut hash = *read_lock;
+        drop(read_lock);
+
+        if !hash.is_zero() {
+            return hash;
+        }
+
+        let hash_bytes = hash.as_bytes_mut();
+
+        let value_len = BYTES_PER_CHUNK / T::tree_hash_packing_factor();
+        for (i, value) in self.values.iter().enumerate() {
+            hash_bytes[i * value_len..(i + 1) * value_len]
+                .copy_from_slice(&value.tree_hash_packed_encoding());
+        }
+
+        *self.hash.write().await = hash;
         hash
     }
 

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -157,7 +157,7 @@ where
 
 fn apply_ops_list<T, N>(list: &mut List<T, N>, spec: &mut Spec<T, N>, ops: Vec<Op<T>>)
 where
-    T: Value + Debug + Send + Sync,
+    T: Value + Debug + Send + Sync + 'static,
     N: Unsigned + Debug,
 {
     let mut checkpoint = list.clone();
@@ -235,7 +235,7 @@ where
 
 fn apply_ops_vect<T, N>(vect: &mut Vector<T, N>, spec: &mut Spec<T, N>, ops: Vec<Op<T>>)
 where
-    T: Value + Debug + Send + Sync,
+    T: Value + Debug + Send + Sync + 'static,
     N: Unsigned + Debug,
 {
     let mut checkpoint = vect.clone();

--- a/src/tests/repeat.rs
+++ b/src/tests/repeat.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use tree_hash::TreeHash;
 use typenum::{Unsigned, U1024, U64, U8};
 
-fn list_test<T: Value + Send + Sync + Debug, N: Unsigned + Debug>(val: T) {
+fn list_test<T: Value + Send + Sync + Debug + 'static, N: Unsigned + Debug>(val: T) {
     for n in 96..=N::to_usize() {
         let fast = List::<T, N>::repeat(val.clone(), n).unwrap();
         let slow = List::<T, N>::repeat_slow(val.clone(), n).unwrap();

--- a/src/tests/size_of.rs
+++ b/src/tests/size_of.rs
@@ -1,6 +1,6 @@
 use crate::{Arc, Leaf, PackedLeaf, Tree};
-use parking_lot::RwLock;
 use std::mem::size_of;
+use tokio::sync::RwLock;
 use tree_hash::Hash256;
 
 /// It's important that the Tree nodes have a predictable size.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{Arc, UpdateMap};
 use arbitrary::Arbitrary;
-use parking_lot::RwLock;
 use std::collections::BTreeMap;
+use tokio::sync::RwLock;
 use tree_hash::{Hash256, TreeHash, TreeHashType};
 
 /// Length type, to avoid confusion with depth and other `usize` parameters.

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -245,7 +245,7 @@ impl<T: Default + Value, N: Unsigned> Default for Vector<T, N> {
     }
 }
 
-impl<T: Value + Send + Sync, N: Unsigned> tree_hash::TreeHash for Vector<T, N> {
+impl<T: Value + Send + Sync + 'static, N: Unsigned> tree_hash::TreeHash for Vector<T, N> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
     }


### PR DESCRIPTION
This is an experimental PR to try using Tokio in place of Rayon. Tokio _also_ uses a work-stealing thread pool for execution, but has better support for mutexes and locks (see https://github.com/rayon-rs/rayon/issues/592).

It turns out that these better locks come with significantly higher overhead, and tree hashing runs 3-4x slower on Tokio than it does on Rayon: 140ms (tokio) vs 40ms (rayon).

This branch needs to be compiled with `tokio_unstable` enabled:

```
RUSTFLAGS="--cfg tokio_unstable" cargo bench -- async_tree_hash_root_list
```