### PR TITLE
Apply updates recursively

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -80,8 +80,13 @@ where
         Ok(())
     }
 
+    pub fn apply_recursive_updates(&mut self) -> Result<(), Error> {
+        self.updates.for_each_mut(|item| item.apply())
+    }
+
     pub fn apply_updates(&mut self) -> Result<(), Error> {
         if !self.updates.is_empty() {
+            self.apply_recursive_updates()?;
             let updates = std::mem::take(&mut self.updates);
             self.backing.update(updates, None)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,20 @@ pub use vector::Vector;
 use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
-pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone {}
+pub trait PendingUpdates {
+    fn apply(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
 
-impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone {}
+pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone + PendingUpdates {}
+
+impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone + PendingUpdates {}
+
+// Default impls for known types
+impl PendingUpdates for u8 {}
+impl PendingUpdates for u16 {}
+impl PendingUpdates for u32 {}
+impl PendingUpdates for u64 {}
+impl PendingUpdates for u128 {}
+impl PendingUpdates for tree_hash::Hash256 {}

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,7 +6,7 @@ use crate::serde::ListVisitor;
 use crate::tree::RebaseAction;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, int_log, opt_packing_depth, updated_length, Length};
-use crate::{Arc, Cow, Error, Tree, UpdateMap, Value};
+use crate::{Arc, Cow, Error, PendingUpdates, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
 use derivative::Derivative;
 use itertools::process_results;
@@ -37,6 +37,12 @@ pub struct ListInner<T: Value, N: Unsigned> {
     pub(crate) packing_depth: usize,
     #[arbitrary(default)]
     _phantom: PhantomData<N>,
+}
+
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> PendingUpdates for List<T, N, U> {
+    fn apply(&mut self) -> Result<(), Error> {
+        self.interface.apply_updates()
+    }
 }
 
 impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,5 +4,6 @@ mod builder;
 mod iterator;
 mod packed;
 mod proptest;
+mod recursion;
 mod repeat;
 mod size_of;

--- a/src/tests/proptest/mod.rs
+++ b/src/tests/proptest/mod.rs
@@ -1,4 +1,4 @@
-use crate::List;
+use crate::{List, PendingUpdates};
 use proptest::prelude::*;
 use ssz_derive::{Decode, Encode};
 use tree_hash::Hash256;
@@ -42,6 +42,14 @@ pub struct Large {
     b: u8,
     c: Hash256,
     d: List<u64, U4>,
+}
+
+impl PendingUpdates for Large {
+    fn apply(&mut self) -> Result<(), crate::Error> {
+        // TODO use macro derive
+        self.d.apply()?;
+        Ok(())
+    }
 }
 
 pub fn arb_large() -> impl Strategy<Value = Large> {

--- a/src/tests/recursion.rs
+++ b/src/tests/recursion.rs
@@ -1,0 +1,66 @@
+use crate::{List, PendingUpdates};
+use ssz_derive::{Decode, Encode};
+use tree_hash::TreeHash;
+use tree_hash_derive::TreeHash;
+use typenum::U16;
+
+#[test]
+fn recursive_list_list() {
+    let mut l = List::<List<u64, U16>, U16>::default();
+
+    l.push(<_>::default()).unwrap();
+    l.get_mut(0).unwrap().push(1).unwrap();
+    l.apply_updates().unwrap();
+    // assert it does not throw
+    let h_1 = l.tree_hash_root();
+
+    assert!(!l.has_pending_updates());
+    assert_eq!(*l.get(0).unwrap().get(0).unwrap(), 1);
+
+    // Replace value
+    *l.get_mut(0).unwrap().get_mut(0).unwrap() = 2;
+    assert_eq!(*l.get(0).unwrap().get(0).unwrap(), 2);
+
+    // Commit only top list
+    l.apply_updates().unwrap();
+    // Root should be different
+    assert_ne!(h_1, l.tree_hash_root());
+}
+
+/// Struct with multiple fields shared by multiple proptests.
+#[derive(Default, Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
+pub struct ListContainer {
+    a: u8,
+    b: List<u64, U16>,
+}
+
+impl PendingUpdates for ListContainer {
+    fn apply(&mut self) -> Result<(), crate::Error> {
+        // TODO use macro derive
+        self.b.apply()?;
+        Ok(())
+    }
+}
+
+#[test]
+fn recursive_list_container_list() {
+    let mut l = List::<ListContainer, U16>::default();
+
+    l.push(<_>::default()).unwrap();
+    l.get_mut(0).unwrap().b.push(1).unwrap();
+    l.apply_updates().unwrap();
+    // assert it does not throw
+    let h_1 = l.tree_hash_root();
+
+    assert!(!l.has_pending_updates());
+    assert_eq!(*l.get(0).unwrap().b.get(0).unwrap(), 1);
+
+    // Replace value
+    *l.get_mut(0).unwrap().b.get_mut(0).unwrap() = 2;
+    assert_eq!(*l.get(0).unwrap().b.get(0).unwrap(), 2);
+
+    // Commit only top list
+    l.apply_updates().unwrap();
+    // Root should be different
+    assert_ne!(h_1, l.tree_hash_root());
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -4,7 +4,7 @@ use crate::iter::Iter;
 use crate::tree::RebaseAction;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, Length};
-use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value};
+use crate::{Arc, Cow, Error, List, PendingUpdates, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -38,6 +38,12 @@ pub struct VectorInner<T: Value, N: Unsigned> {
     packing_depth: usize,
     #[arbitrary(default)]
     _phantom: PhantomData<N>,
+}
+
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> PendingUpdates for Vector<T, N, U> {
+    fn apply(&mut self) -> Result<(), Error> {
+        self.interface.apply_updates()
+    }
 }
 
 impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {


### PR DESCRIPTION
### Motivation

Current main branch has a foot gun for nested List/Vectors. The code below will panic on `tree_hash_root` because `l_sub` still has pending updates. Ethereum consensus does have many nested complex types that involve mutability, but it would be nice to remove the possibility of runtime errors if there's not much overhead.

```rs
let mut l = List::<List<u64, U16>, U16>::default();

l.push(<_>::default()).unwrap();
let l_sub = l.get_mut(0).unwrap();
l_sub.push(1).unwrap();
let v = l_sub.get_mut(0).unwrap();
assert_eq!(*v, 1);
// l_sub.apply_updates().unwrap(); <<- Needs this line to not panic
l.apply_updates().unwrap();
l.tree_hash_root()
```

### Impl

This PR introduces a new trait `PendingUpdates` that all values of List / Vector must implement. I'll take suggestions for a better name, since this will be very prevalent in the Lighthouse codebase.

@michaelsproul comments that the compiler may optimize an `apply` implementation inside of the `for_each_mut` loop away. However I'm not sure if that's the case with a Result involved + the current impl. Open to feedback.

## Next 

[ ] derive macro to implement `PendingUpdates` for structs