### PR TITLE
Implement `pop_front` in terms of a level iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ proptest = "1.0.0"
 tree_hash_derive = "0.6.0"
 criterion = "0.5"
 
+[features]
+debug = []
+
 [[bench]]
 name = "rebase"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ethereum-types = { version = "0.14.1", features = ["arbitrary"] }
 ssz_types = "0.6.0"
 proptest = "1.0.0"
 tree_hash_derive = "0.6.0"
-criterion = "0.3"
+criterion = "0.5"
 
 [[bench]]
 name = "rebase"
@@ -43,4 +43,8 @@ harness = false
 
 [[bench]]
 name = "ssz"
+harness = false
+
+[[bench]]
+name = "pop_front"
 harness = false

--- a/benches/pop_front.rs
+++ b/benches/pop_front.rs
@@ -1,0 +1,61 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use milhouse::{List, Value};
+use typenum::Unsigned;
+
+type C = typenum::U1099511627776;
+const N: u64 = 800_000;
+
+#[inline]
+fn pop_front<T: Value, N: Unsigned>(list: &List<T, N>, n: usize) -> List<T, N> {
+    let mut list_popped = list.clone();
+    list_popped.pop_front(n).unwrap();
+    list_popped
+}
+
+pub fn pop_front_list_u64(c: &mut Criterion) {
+    let size = N;
+
+    let base_list = List::<u64, C>::try_from_iter(0..size).unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new("pop_front_noop", size),
+        &base_list,
+        |b, list| {
+            b.iter(|| pop_front(list, 0));
+        },
+    );
+    // This is one of the worst cases because we can't reuse any nodes.
+    c.bench_with_input(
+        BenchmarkId::new("pop_front_3", size),
+        &base_list,
+        |b, list| {
+            b.iter(|| pop_front(list, 3));
+        },
+    );
+    // This should be a bit quicker because we are aligned to the packing factor and can copy whole
+    // leaves.
+    c.bench_with_input(
+        BenchmarkId::new("pop_front_4", size),
+        &base_list,
+        |b, list| {
+            b.iter(|| pop_front(list, 4));
+        },
+    );
+    c.bench_with_input(
+        BenchmarkId::new("pop_front_32", size),
+        &base_list,
+        |b, list| {
+            b.iter(|| pop_front(list, 32));
+        },
+    );
+    c.bench_with_input(
+        BenchmarkId::new("pop_front_400k", size),
+        &base_list,
+        |b, list| {
+            b.iter(|| pop_front(list, 400_000));
+        },
+    );
+}
+
+criterion_group!(benches, pop_front_list_u64);
+criterion_main!(benches);

--- a/benches/rebase.rs
+++ b/benches/rebase.rs
@@ -24,28 +24,28 @@ pub fn rebase_list(c: &mut Criterion) {
     c.bench_with_input(
         BenchmarkId::new("rebase_identical", size),
         &(identical.clone(), base_list.clone()),
-        |b, &(ref l1, ref l2)| {
+        |b, (l1, l2)| {
             b.iter(|| rebase(l1, l2));
         },
     );
     c.bench_with_input(
         BenchmarkId::new("rebase_push_1_back", size),
         &(push_1_back.clone(), base_list.clone()),
-        |b, &(ref l1, ref l2)| {
+        |b, (l1, l2)| {
             b.iter(|| rebase(l1, l2));
         },
     );
     c.bench_with_input(
         BenchmarkId::new("rebase_mutate0", size),
         &(mutate_0.clone(), base_list.clone()),
-        |b, &(ref l1, ref l2)| {
+        |b, (l1, l2)| {
             b.iter(|| rebase(l1, l2));
         },
     );
     c.bench_with_input(
         BenchmarkId::new("rebase_completely_different", size),
         &(completely_different.clone(), base_list.clone()),
-        |b, &(ref l1, ref l2)| {
+        |b, (l1, l2)| {
             b.iter(|| rebase(l1, l2));
         },
     );

--- a/benches/ssz.rs
+++ b/benches/ssz.rs
@@ -16,8 +16,8 @@ fn encode_list<T: Value, N: Unsigned>(l1: &List<T, N>) -> Vec<u8> {
 #[inline]
 fn encode_decode_list<T: Value, N: Unsigned>(l1: &List<T, N>) -> List<T, N> {
     let bytes = l1.as_ssz_bytes();
-    let l2 = List::from_ssz_bytes(&bytes).unwrap();
-    l2
+
+    List::from_ssz_bytes(&bytes).unwrap()
 }
 
 #[inline]
@@ -28,8 +28,8 @@ fn encode_vector<T: Value, N: Unsigned>(v1: &Vector<T, N>) -> Vec<u8> {
 #[inline]
 fn encode_decode_vector<T: Value, N: Unsigned>(v1: &Vector<T, N>) -> Vector<T, N> {
     let bytes = v1.as_ssz_bytes();
-    let v2 = Vector::from_ssz_bytes(&bytes).unwrap();
-    v2
+
+    Vector::from_ssz_bytes(&bytes).unwrap()
 }
 
 #[inline]
@@ -42,8 +42,8 @@ fn encode_decode_variable_list<T: Value, N: Unsigned>(
     l1: &VariableList<T, N>,
 ) -> VariableList<T, N> {
     let bytes = l1.as_ssz_bytes();
-    let l2 = VariableList::from_ssz_bytes(&bytes).unwrap();
-    l2
+
+    VariableList::from_ssz_bytes(&bytes).unwrap()
 }
 
 pub fn ssz(c: &mut Criterion) {
@@ -54,14 +54,14 @@ pub fn ssz(c: &mut Criterion) {
     let variable_list = VariableList::<u64, C>::new((0..size).collect()).unwrap();
 
     c.bench_with_input(BenchmarkId::new("ssz_encode_list", size), &list, |b, l1| {
-        b.iter(|| encode_list(&l1));
+        b.iter(|| encode_list(l1));
     });
 
     c.bench_with_input(
         BenchmarkId::new("ssz_encode_decode_list", size),
         &list,
         |b, l1| {
-            b.iter(|| encode_decode_list(&l1));
+            b.iter(|| encode_decode_list(l1));
         },
     );
 
@@ -69,7 +69,7 @@ pub fn ssz(c: &mut Criterion) {
         BenchmarkId::new("ssz_encode_vector", size),
         &vector,
         |b, v1| {
-            b.iter(|| encode_vector(&v1));
+            b.iter(|| encode_vector(v1));
         },
     );
 
@@ -77,7 +77,7 @@ pub fn ssz(c: &mut Criterion) {
         BenchmarkId::new("ssz_encode_decode_vector", size),
         &vector,
         |b, v1| {
-            b.iter(|| encode_decode_vector(&v1));
+            b.iter(|| encode_decode_vector(v1));
         },
     );
 
@@ -86,7 +86,7 @@ pub fn ssz(c: &mut Criterion) {
         BenchmarkId::new("ssz_encode_variable_list", size),
         &variable_list,
         |b, l1| {
-            b.iter(|| encode_variable_list(&l1));
+            b.iter(|| encode_variable_list(l1));
         },
     );
 
@@ -95,7 +95,7 @@ pub fn ssz(c: &mut Criterion) {
         BenchmarkId::new("ssz_encode_decode_variable_list", size),
         &variable_list,
         |b, l1| {
-            b.iter(|| encode_decode_variable_list(&l1));
+            b.iter(|| encode_decode_variable_list(l1));
         },
     );
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -64,12 +64,12 @@ impl<T: Value> Builder<T> {
 
         let mut new_stack_top = MaybeArced::Arced(node);
 
-        let values_to_merge = if self.level > self.packing_depth {
-            next_index.trailing_zeros()
-        } else {
+        let values_to_merge = if self.level == 0 {
             next_index
                 .trailing_zeros()
                 .saturating_sub(self.packing_depth as u32)
+        } else {
+            next_index.trailing_zeros()
         };
 
         for _ in 0..values_to_merge {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -64,6 +64,9 @@ impl<T: Value> Builder<T> {
 
         let mut new_stack_top = MaybeArced::Arced(node);
 
+        // Subtract the packing depth if we are on level 0, in which case `next_index` includes
+        // `packing_depth` trailing bits which don't correspond to stack entries and should not be
+        // popped.
         let values_to_merge = if self.level == 0 {
             next_index
                 .trailing_zeros()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -59,8 +59,8 @@ impl<T: Value> Builder<T> {
     }
 
     pub fn push_node(&mut self, node: Arc<Tree<T>>, len: usize) -> Result<(), Error> {
-        let index = self.length.as_usize() >> self.level;
-        let next_index = index + 1;
+        let index_on_level = self.length.as_usize() >> self.level;
+        let next_index_on_level = index_on_level + 1;
 
         let mut new_stack_top = MaybeArced::Arced(node);
 
@@ -68,11 +68,11 @@ impl<T: Value> Builder<T> {
         // `packing_depth` trailing bits which don't correspond to stack entries and should not be
         // popped.
         let values_to_merge = if self.level == 0 {
-            next_index
+            next_index_on_level
                 .trailing_zeros()
                 .saturating_sub(self.packing_depth as u32)
         } else {
-            next_index.trailing_zeros()
+            next_index_on_level.trailing_zeros()
         };
 
         for _ in 0..values_to_merge {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,7 @@ pub enum Error {
     BuilderStackLeftover,
     BulkUpdateUnclean,
     CowMissingEntry,
+    LevelIterPendingUpdates,
 }
 
 impl Display for Error {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,3 +1,4 @@
+use crate::level_iter::LevelIter;
 use crate::update_map::UpdateMap;
 use crate::utils::{updated_length, Length};
 use crate::{
@@ -20,6 +21,8 @@ pub trait ImmList<T: Value> {
     }
 
     fn iter_from(&self, index: usize) -> Iter<T>;
+
+    fn level_iter_from(&self, index: usize) -> LevelIter<T>;
 }
 
 pub trait MutList<T: Value>: ImmList<T> {
@@ -112,6 +115,14 @@ where
             tree_iter: self.backing.iter_from(index),
             updates: &mut self.updates,
             index,
+        }
+    }
+
+    pub fn level_iter_from(&self, index: usize) -> Result<LevelIter<T>, Error> {
+        if self.has_pending_updates() {
+            Err(Error::LevelIterPendingUpdates)
+        } else {
+            Ok(self.backing.level_iter_from(index))
         }
     }
 

--- a/src/level_iter.rs
+++ b/src/level_iter.rs
@@ -9,6 +9,8 @@ pub struct LevelIter<'a, T: Value> {
     /// Stack of tree nodes corresponding to the current position.
     stack: Vec<&'a Arc<Tree<T>>>,
     /// The list index corresponding to the current position (next element to be yielded).
+    ///
+    /// This is the index of the leaf/element at the bottom of the subtree.
     index: usize,
     /// The level of the tree being iterated.
     level: usize,

--- a/src/level_iter.rs
+++ b/src/level_iter.rs
@@ -3,7 +3,6 @@ use crate::{
     Arc, PackedLeaf, Tree, Value,
 };
 
-// FIXME(sproul): clean up and simplify
 /// Iterator over the internal nodes at a given `depth` (level) in a tree.
 #[derive(Debug)]
 pub struct LevelIter<'a, T: Value> {
@@ -21,7 +20,7 @@ pub struct LevelIter<'a, T: Value> {
     packing_factor: usize,
     /// Cached packing depth to avoid re-calculating `opt_packing_depth`.
     packing_depth: usize,
-    /// Number of items that will be yielded by the iterator.
+    /// Number of elements in the list being iterated.
     length: Length,
 }
 
@@ -73,7 +72,7 @@ impl<'a, T: Value> Iterator for LevelIter<'a, T> {
                 let result = Some(LevelNode::Internal(node));
 
                 // If we are iterating leaves then the level must be 0.
-                assert_eq!(self.level, 0);
+                debug_assert_eq!(self.level, 0);
                 self.index += 1;
 
                 // Backtrack to the parent node of the next subtree
@@ -93,7 +92,7 @@ impl<'a, T: Value> Iterator for LevelIter<'a, T> {
                     self.index += 1 << self.level;
 
                     let trailing_zeros = self.index.trailing_zeros() as usize;
-                    assert!(trailing_zeros >= self.level);
+                    debug_assert!(trailing_zeros >= self.level);
                     let to_pop = trailing_zeros.saturating_add(1).saturating_sub(self.level);
 
                     // Backtrack to the parent node of the next subtree
@@ -108,7 +107,7 @@ impl<'a, T: Value> Iterator for LevelIter<'a, T> {
                 let result = values.get(sub_index).map(LevelNode::PackedLeaf);
 
                 // If we are iterating leaves then the level must be 0.
-                assert_eq!(self.level, 0);
+                debug_assert_eq!(self.level, 0);
                 self.index += 1;
 
                 // Reached end of chunk
@@ -137,7 +136,7 @@ impl<'a, T: Value> Iterator for LevelIter<'a, T> {
                     self.index += 1 << self.level;
 
                     let trailing_zeros = self.index.trailing_zeros() as usize;
-                    assert!(trailing_zeros >= self.level);
+                    debug_assert!(trailing_zeros >= self.level);
                     let to_pop = trailing_zeros.saturating_add(1).saturating_sub(self.level);
 
                     // Backtrack to the parent node of the next subtree

--- a/src/level_iter.rs
+++ b/src/level_iter.rs
@@ -1,0 +1,139 @@
+use crate::{
+    utils::{opt_packing_depth, opt_packing_factor, Length},
+    Arc, PackedLeaf, Tree, Value,
+};
+
+// FIXME(sproul): clean up and simplify
+/// Iterator over the internal nodes at a given `depth` (level) in a tree.
+#[derive(Debug)]
+pub struct LevelIter<'a, T: Value> {
+    /// Stack of tree nodes corresponding to the current position.
+    stack: Vec<&'a Arc<Tree<T>>>,
+    /// The list index corresponding to the current position (next element to be yielded).
+    index: usize,
+    /// The level of the tree being iterated.
+    level: usize,
+    /// The `depth` of the root tree.
+    full_depth: usize,
+    /// Cached packing factor to avoid re-calculating `opt_packing_factor`.
+    ///
+    /// Initialised to 0 if `T` is not packed.
+    packing_factor: usize,
+    /// Cached packing depth to avoid re-calculating `opt_packing_depth`.
+    packing_depth: usize,
+    /// Number of items that will be yielded by the iterator.
+    length: Length,
+}
+
+/// Item yielded by a `LevelIter`.
+///
+/// If we are iterating an internal level, then all `Internal` nodes `Arc` pointers will be
+/// returned. Otherwise if we are iterating at the leaf level over packed leaves, references to
+/// leaves will be returned.
+#[derive(Debug)]
+pub enum LevelNode<'a, T: Value> {
+    Internal(&'a Arc<Tree<T>>),
+    PackedLeaf(&'a T),
+}
+
+impl<'a, T: Value> LevelIter<'a, T> {
+    pub fn from_index(index: usize, root: &'a Arc<Tree<T>>, depth: usize, length: Length) -> Self {
+        let mut stack = Vec::with_capacity(depth);
+        stack.push(root);
+
+        let level = index.trailing_zeros() as usize;
+
+        LevelIter {
+            stack,
+            index,
+            level,
+            full_depth: depth,
+            packing_factor: opt_packing_factor::<T>().unwrap_or(0),
+            packing_depth: opt_packing_depth::<T>().unwrap_or(0),
+            length,
+        }
+    }
+}
+
+impl<'a, T: Value> Iterator for LevelIter<'a, T> {
+    type Item = LevelNode<'a, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.length.as_usize() {
+            return None;
+        }
+
+        let node: &'a Arc<Tree<T>> = *self.stack.last()?;
+        match node.as_ref() {
+            Tree::Zero(_) => None,
+            Tree::Leaf(_) => {
+                let result = Some(LevelNode::Internal(node));
+
+                // If we are iterating leaves then the level must be 0.
+                assert_eq!(self.level, 0);
+                self.index += 1;
+
+                // Backtrack to the parent node of the next subtree
+                for _ in 0..=self.index.trailing_zeros() {
+                    self.stack.pop();
+                }
+
+                result
+            }
+            Tree::PackedLeaf(PackedLeaf { values, .. }) => {
+                let sub_index = self.index % self.packing_factor;
+
+                let result = values.get(sub_index).map(LevelNode::PackedLeaf);
+
+                // If we are iterating leaves then the level must be less than or equal to the
+                // packing depth.
+                assert!(self.level <= self.packing_depth);
+                self.index += 1;
+
+                // Reached end of chunk
+                if sub_index + 1 == self.packing_factor {
+                    let to_pop = self
+                        .index
+                        .trailing_zeros()
+                        .checked_sub(self.packing_depth as u32)
+                        .expect("index should have at least `packing_depth` trailing zeroes");
+
+                    for _ in 0..=to_pop {
+                        self.stack.pop();
+                    }
+                }
+
+                result
+            }
+            Tree::Node { left, right, .. } => {
+                let depth = self.full_depth - self.stack.len();
+
+                if depth + self.packing_depth == self.level {
+                    let result = Some(LevelNode::Internal(node));
+
+                    // Jump to the next index on the same level.
+                    self.index += 1 << self.level;
+
+                    let trailing_zeros = self.index.trailing_zeros() as usize;
+                    assert!(trailing_zeros >= self.level);
+                    let to_pop = trailing_zeros - self.level;
+
+                    // Backtrack to the parent node of the next subtree
+                    for _ in 0..to_pop {
+                        self.stack.pop();
+                    }
+
+                    result
+                } else if (self.index >> (depth + self.packing_depth)) & 1 == 0 {
+                    // Go left
+                    self.stack.push(left);
+                    self.next()
+                } else {
+                    // Go right
+                    self.stack.push(right);
+                    self.next()
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub use vector::Vector;
 use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
+// FIXME(sproul): remove Debug
 pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}
 
 impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,14 @@ pub use vector::Vector;
 use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
-// FIXME(sproul): remove Debug
+#[cfg(feature = "debug")]
 pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}
 
+#[cfg(feature = "debug")]
 impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}
+
+#[cfg(not(feature = "debug"))]
+pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone {}
+
+#[cfg(not(feature = "debug"))]
+impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod interface;
 pub mod interface_iter;
 pub mod iter;
 pub mod leaf;
+pub mod level_iter;
 pub mod list;
 pub mod packed_leaf;
 mod repeat;
@@ -32,6 +33,6 @@ pub use vector::Vector;
 use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
-pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone {}
+pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}
 
-impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone {}
+impl<T> Value for T where T: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}

--- a/src/list.rs
+++ b/src/list.rs
@@ -201,11 +201,6 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
             return Ok(());
         }
 
-        /*
-        if 2 + 2 == 4 {
-            return self.pop_front_slow(n);
-        }
-        */
         let depth = Self::depth();
         let packing_depth = opt_packing_depth::<T>().unwrap_or(0);
         let level = compute_level(n, depth, packing_depth);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@
 mod builder;
 mod iterator;
 mod packed;
+mod pop_front;
 mod proptest;
 mod repeat;
 mod size_of;

--- a/src/tests/pop_front.rs
+++ b/src/tests/pop_front.rs
@@ -32,6 +32,36 @@ fn level_iter_pop_front_basic_packed() {
 }
 
 #[test]
+fn level_iter_pop_front_basic_packed_17() {
+    let vec = vec![
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 0, 0, 0, 0, 0, 666,
+    ];
+    let list = List::<u64, U32>::new(vec.clone()).unwrap();
+    assert_eq!(list.len(), 17);
+
+    for from in 0..vec.len() {
+        let mut list = list.clone();
+        for (i, level) in list.level_iter_from(from).unwrap().enumerate() {
+            match level {
+                LevelNode::PackedLeaf(leaf) => {
+                    assert!(from.trailing_zeros() <= 2);
+                    assert_eq!(*leaf, vec[i + from]);
+                }
+                LevelNode::Internal(node) => {
+                    let level = if from == 0 { 5 } else { from.trailing_zeros() };
+                    assert!(level > 2);
+                    assert!(node.compute_len() <= 1 << level);
+                }
+            }
+        }
+
+        list.pop_front(from).unwrap();
+        assert_eq!(list.len(), vec.len() - from);
+        assert_eq!(list.to_vec().as_slice(), &vec[from..]);
+    }
+}
+
+#[test]
 fn level_iter_pop_front_basic_large() {
     let vec = (0..7u8)
         .map(|i| Large {
@@ -45,7 +75,6 @@ fn level_iter_pop_front_basic_large() {
     assert_eq!(list.len(), 7);
 
     for from in 0..vec.len() {
-        println!("from = {from}");
         let mut list = list.clone();
         list.pop_front(from).unwrap();
         assert_eq!(list.len(), vec.len() - from);

--- a/src/tests/pop_front.rs
+++ b/src/tests/pop_front.rs
@@ -1,0 +1,24 @@
+use crate::{level_iter::LevelNode, List};
+use typenum::U32;
+
+#[test]
+fn level_iter_from_basic() {
+    let vec = vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+    let mut list = List::<u64, U32>::new(vec.clone()).unwrap();
+    assert_eq!(list.len(), 11);
+
+    let from = 1;
+    for (i, level) in list.level_iter_from(from).unwrap().enumerate() {
+        let LevelNode::PackedLeaf(leaf) = level else {
+            panic!("not a packed leaf: {level:?}")
+        };
+        assert_eq!(*leaf, vec[i + from]);
+    }
+
+    list.pop_front(1).unwrap();
+    assert_eq!(list.len(), vec.len() - 1);
+    list.pop_front(2).unwrap();
+    assert_eq!(list.len(), vec.len() - 3);
+
+    assert_eq!(list.to_vec().as_slice(), &vec[3..]);
+}

--- a/src/tests/pop_front.rs
+++ b/src/tests/pop_front.rs
@@ -9,17 +9,17 @@ fn level_iter_pop_front_basic_packed() {
     let list = List::<u64, U32>::new(vec.clone()).unwrap();
     assert_eq!(list.len(), 11);
 
-    for from in 0..vec.len() {
+    for from in 4..vec.len() {
         let mut list = list.clone();
         for (i, level) in list.level_iter_from(from).unwrap().enumerate() {
             match level {
                 LevelNode::PackedLeaf(leaf) => {
-                    assert!(from.trailing_zeros() <= 2);
+                    assert!(from.trailing_zeros() < 2, "from = {from}");
                     assert_eq!(*leaf, vec[i + from]);
                 }
                 LevelNode::Internal(node) => {
                     let level = if from == 0 { 5 } else { from.trailing_zeros() };
-                    assert!(level > 2);
+                    assert!(level >= 2);
                     assert!(node.compute_len() <= 1 << level);
                 }
             }
@@ -44,12 +44,12 @@ fn level_iter_pop_front_basic_packed_17() {
         for (i, level) in list.level_iter_from(from).unwrap().enumerate() {
             match level {
                 LevelNode::PackedLeaf(leaf) => {
-                    assert!(from.trailing_zeros() <= 2);
+                    assert!(from.trailing_zeros() < 2);
                     assert_eq!(*leaf, vec[i + from]);
                 }
                 LevelNode::Internal(node) => {
                     let level = if from == 0 { 5 } else { from.trailing_zeros() };
-                    assert!(level > 2);
+                    assert!(level >= 2);
                     assert!(node.compute_len() <= 1 << level);
                 }
             }

--- a/src/tests/pop_front.rs
+++ b/src/tests/pop_front.rs
@@ -1,24 +1,78 @@
-use crate::{level_iter::LevelNode, List};
-use typenum::U32;
+use crate::tests::proptest::Large;
+use crate::{level_iter::LevelNode, Arc, List};
+use tree_hash::Hash256;
+use typenum::{U32, U8};
 
 #[test]
-fn level_iter_from_basic() {
+fn level_iter_pop_front_basic_packed() {
     let vec = vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
-    let mut list = List::<u64, U32>::new(vec.clone()).unwrap();
+    let list = List::<u64, U32>::new(vec.clone()).unwrap();
     assert_eq!(list.len(), 11);
 
-    let from = 1;
-    for (i, level) in list.level_iter_from(from).unwrap().enumerate() {
-        let LevelNode::PackedLeaf(leaf) = level else {
-            panic!("not a packed leaf: {level:?}")
-        };
-        assert_eq!(*leaf, vec[i + from]);
+    for from in 0..vec.len() {
+        let mut list = list.clone();
+        for (i, level) in list.level_iter_from(from).unwrap().enumerate() {
+            match level {
+                LevelNode::PackedLeaf(leaf) => {
+                    assert!(from.trailing_zeros() <= 2);
+                    assert_eq!(*leaf, vec[i + from]);
+                }
+                LevelNode::Internal(node) => {
+                    let level = if from == 0 { 5 } else { from.trailing_zeros() };
+                    assert!(level > 2);
+                    assert!(node.compute_len() <= 1 << level);
+                }
+            }
+        }
+
+        list.pop_front(from).unwrap();
+        assert_eq!(list.len(), vec.len() - from);
+        assert_eq!(list.to_vec().as_slice(), &vec[from..]);
     }
+}
 
-    list.pop_front(1).unwrap();
-    assert_eq!(list.len(), vec.len() - 1);
-    list.pop_front(2).unwrap();
-    assert_eq!(list.len(), vec.len() - 3);
+#[test]
+fn level_iter_pop_front_basic_large() {
+    let vec = (0..7u8)
+        .map(|i| Large {
+            a: i as u64,
+            b: i,
+            c: Hash256::repeat_byte(i),
+            d: List::empty(),
+        })
+        .collect::<Vec<_>>();
+    let list = List::<Large, U8>::new(vec.clone()).unwrap();
+    assert_eq!(list.len(), 7);
 
-    assert_eq!(list.to_vec().as_slice(), &vec[3..]);
+    for from in 0..vec.len() {
+        println!("from = {from}");
+        let mut list = list.clone();
+        list.pop_front(from).unwrap();
+        assert_eq!(list.len(), vec.len() - from);
+        assert_eq!(list.to_vec().as_slice(), &vec[from..]);
+    }
+}
+
+#[test]
+fn pop_front_zero_noop() {
+    let vec = vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+    let mut list = List::<u64, U32>::new(vec.clone()).unwrap();
+
+    list.apply_updates().unwrap();
+    let mut popped_list = list.clone();
+    popped_list.pop_front(0).unwrap();
+
+    for (a, b) in list
+        .level_iter_from(0)
+        .unwrap()
+        .zip(popped_list.level_iter_from(0).unwrap())
+    {
+        let LevelNode::Internal(a) = a else {
+            panic!("internal node expected")
+        };
+        let LevelNode::Internal(b) = b else {
+            panic!("internal node expected")
+        };
+        assert!(Arc::ptr_eq(a, b));
+    }
 }

--- a/src/tests/proptest/mod.rs
+++ b/src/tests/proptest/mod.rs
@@ -38,10 +38,10 @@ pub fn arb_hash256() -> impl Strategy<Value = Hash256> {
 /// Struct with multiple fields shared by multiple proptests.
 #[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct Large {
-    a: u64,
-    b: u8,
-    c: Hash256,
-    d: List<u64, U4>,
+    pub a: u64,
+    pub b: u8,
+    pub c: Hash256,
+    pub d: List<u64, U4>,
 }
 
 pub fn arb_large() -> impl Strategy<Value = Large> {

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -17,7 +17,7 @@ pub struct Spec<T, N: Unsigned> {
     _phantom: PhantomData<N>,
 }
 
-impl<T, N: Unsigned> Spec<T, N> {
+impl<T: Value, N: Unsigned> Spec<T, N> {
     pub fn list(values: Vec<T>) -> Self {
         assert!(values.len() <= N::to_usize());
         Self {
@@ -47,6 +47,18 @@ impl<T, N: Unsigned> Spec<T, N> {
     pub fn iter_from(&self, index: usize) -> Result<impl Iterator<Item = &T>, Error> {
         if index <= self.len() {
             Ok(self.values[index..].iter())
+        } else {
+            Err(Error::OutOfBoundsIterFrom {
+                index,
+                len: self.len(),
+            })
+        }
+    }
+
+    pub fn pop_front(&mut self, index: usize) -> Result<(), Error> {
+        if index <= self.len() {
+            self.values = self.values[index..].to_vec();
+            Ok(())
         } else {
             Err(Error::OutOfBoundsIterFrom {
                 index,
@@ -97,6 +109,8 @@ pub enum Op<T> {
     Iter,
     /// Check the `iter_from` method.
     IterFrom(usize),
+    /// Check the `pop_front` method.
+    PopFront(usize),
     /// Apply updates to the backing list.
     ApplyUpdates,
     /// Compute the tree hash of the list, modifying its internal nodes.
@@ -128,10 +142,11 @@ where
         strategy.prop_map(Op::Push),
         Just(Op::Iter),
         arb_index(n).prop_map(Op::IterFrom),
+        arb_index(n).prop_map(Op::PopFront),
         Just(Op::ApplyUpdates),
-        Just(Op::TreeHash),
     ];
     let b_block = prop_oneof![
+        Just(Op::TreeHash),
         Just(Op::Checkpoint),
         Just(Op::Rebase),
         Just(Op::Debase),
@@ -139,7 +154,7 @@ where
     ];
     prop_oneof![
         10 => a_block,
-        4 => b_block
+        5 => b_block
     ]
 }
 
@@ -196,6 +211,11 @@ where
                 (Ok(iter1), Ok(iter2)) => assert!(iter1.eq(iter2)),
                 (Err(e1), Err(e2)) => assert_eq!(e1, e2),
                 (Err(e), _) | (_, Err(e)) => panic!("iter_from mismatch: {}", e),
+            },
+            Op::PopFront(index) => match (list.pop_front(index), spec.pop_front(index)) {
+                (Ok(()), Ok(())) => assert!(list.iter().eq(spec.iter())),
+                (Err(e1), Err(e2)) => assert_eq!(e1, e2),
+                (Err(e), _) | (_, Err(e)) => panic!("pop_front mismatch: {}", e),
             },
             Op::ApplyUpdates => {
                 list.apply_updates().unwrap();
@@ -275,6 +295,9 @@ where
                 (Err(e1), Err(e2)) => assert_eq!(e1, e2),
                 (Err(e), _) | (_, Err(e)) => panic!("iter_from mismatch: {}", e),
             },
+            Op::PopFront(_) => {
+                // No-op
+            }
             Op::ApplyUpdates => {
                 vect.apply_updates().unwrap();
             }

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -213,7 +213,10 @@ where
                 (Err(e), _) | (_, Err(e)) => panic!("iter_from mismatch: {}", e),
             },
             Op::PopFront(index) => match (list.pop_front(index), spec.pop_front(index)) {
-                (Ok(()), Ok(())) => assert!(list.iter().eq(spec.iter())),
+                (Ok(()), Ok(())) => {
+                    assert_eq!(list.len(), spec.len());
+                    assert!(list.iter().eq(spec.iter()))
+                }
                 (Err(e1), Err(e2)) => assert_eq!(e1, e2),
                 (Err(e), _) | (_, Err(e)) => panic!("pop_front mismatch: {}", e),
             },

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -234,6 +234,19 @@ impl<T: Value> Tree<T> {
             _ => Err(Error::UpdateLeavesError),
         }
     }
+
+    /// Compute the number of elements stored in this subtree.
+    ///
+    /// This method should be avoided if possible. Prefer to read the length cached in a `List` or
+    /// similar.
+    pub fn compute_len(&self) -> usize {
+        match self {
+            Self::Leaf(_) => 1,
+            Self::PackedLeaf(leaf) => leaf.values.len(),
+            Self::Node { left, right, .. } => left.compute_len() + right.compute_len(),
+            Self::Zero(_) => 0,
+        }
+    }
 }
 
 pub enum RebaseAction<'a, T> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,13 +18,6 @@ impl<T> MaybeArced<T> {
             Self::Unarced(value) => Arc::new(value),
         }
     }
-
-    pub fn as_ref(&self) -> &T {
-        match self {
-            Self::Arced(arc) => &*arc,
-            Self::Unarced(value) => &value,
-        }
-    }
 }
 
 /// Length type, to avoid confusion with depth and other `usize` parameters.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,10 +54,15 @@ pub fn int_log(n: usize) -> usize {
 }
 
 pub fn compute_level(index: usize, depth: usize, packing_depth: usize) -> usize {
-    if index == 0 {
+    let raw_level = if index == 0 {
         depth + packing_depth
     } else {
         index.trailing_zeros() as usize
+    };
+    if raw_level <= packing_depth {
+        0
+    } else {
+        raw_level
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,7 +52,7 @@ pub fn compute_level(index: usize, depth: usize, packing_depth: usize) -> usize 
     } else {
         index.trailing_zeros() as usize
     };
-    if raw_level <= packing_depth {
+    if raw_level < packing_depth {
         0
     } else {
         raw_level

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use tree_hash::{Hash256, TreeHash, TreeHashType};
 
 /// Type to abstract over whether `T` is wrapped in an `Arc` or not.
+#[derive(Debug)]
 pub enum MaybeArced<T> {
     Arced(Arc<T>),
     Unarced(T),
@@ -15,6 +16,13 @@ impl<T> MaybeArced<T> {
         match self {
             Self::Arced(arc) => arc,
             Self::Unarced(value) => Arc::new(value),
+        }
+    }
+
+    pub fn as_ref(&self) -> &T {
+        match self {
+            Self::Arced(arc) => &*arc,
+            Self::Unarced(value) => &value,
         }
     }
 }
@@ -42,6 +50,14 @@ pub fn int_log(n: usize) -> usize {
     match n.checked_next_power_of_two() {
         Some(x) => x.trailing_zeros() as usize,
         None => 8 * std::mem::size_of::<usize>(),
+    }
+}
+
+pub fn compute_level(index: usize, depth: usize, packing_depth: usize) -> usize {
+    if index == 0 {
+        depth + packing_depth
+    } else {
+        index.trailing_zeros() as usize
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,21 @@ use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use tree_hash::{Hash256, TreeHash, TreeHashType};
 
+/// Type to abstract over whether `T` is wrapped in an `Arc` or not.
+pub enum MaybeArced<T> {
+    Arced(Arc<T>),
+    Unarced(T),
+}
+
+impl<T> MaybeArced<T> {
+    pub fn arced(self) -> Arc<T> {
+        match self {
+            Self::Arced(arc) => arc,
+            Self::Unarced(value) => Arc::new(value),
+        }
+    }
+}
+
 /// Length type, to avoid confusion with depth and other `usize` parameters.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Arbitrary)]
 pub struct Length(pub usize);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,11 @@ pub fn int_log(n: usize) -> usize {
     }
 }
 
+/// Compute the depth of the largest subtree which has the `index`th element as its 0th leaf.
+///
+/// A level is fundamentally the same as a depth, it is a value `0..=depth` such that a subtree
+/// at that level (depth) contains up to 2^level elements at the leaves. Level 0 is the level of
+/// leaves and packed leaves.
 pub fn compute_level(index: usize, depth: usize, packing_depth: usize) -> usize {
     let raw_level = if index == 0 {
         depth + packing_depth
@@ -103,4 +108,34 @@ pub fn arb_rwlock<'a, T: Arbitrary<'a>>(
     u: &mut arbitrary::Unstructured<'a>,
 ) -> arbitrary::Result<RwLock<T>> {
     T::arbitrary(u).map(RwLock::new)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The level of an odd index is always 0.
+    #[test]
+    fn odd_index_level() {
+        let depth = 5;
+        let packing_depth = 0;
+        for i in (0..2usize.pow(depth as u32)).filter(|i| i % 2 == 1) {
+            assert_eq!(compute_level(i, depth, packing_depth), 0);
+        }
+    }
+
+    /// The level of indices below the packing depth is 0.
+    #[test]
+    fn packing_depth_level() {
+        let depth = 10;
+        let packing_depth = 3;
+        assert_eq!(
+            compute_level(0, depth, packing_depth),
+            depth + packing_depth
+        );
+        assert_eq!(compute_level(1, depth, packing_depth), 0);
+        assert_eq!(compute_level(2, depth, packing_depth), 0);
+        assert_eq!(compute_level(4, depth, packing_depth), 0);
+        assert_eq!(compute_level(8, depth, packing_depth), 3);
+    }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,7 @@
 use crate::interface::{ImmList, Interface, MutList};
 use crate::interface_iter::InterfaceIter;
 use crate::iter::Iter;
+use crate::level_iter::LevelIter;
 use crate::tree::RebaseAction;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, Length};
@@ -190,6 +191,10 @@ impl<T: Value, N: Unsigned> ImmList<T> for VectorInner<T, N> {
 
     fn iter_from(&self, index: usize) -> Iter<T> {
         Iter::from_index(index, &self.tree, self.depth, Length(N::to_usize()))
+    }
+
+    fn level_iter_from(&self, index: usize) -> LevelIter<T> {
+        LevelIter::from_index(index, &self.tree, self.depth, Length(N::to_usize()))
     }
 }
 


### PR DESCRIPTION
For MaxEB we need methods to _slice_ an SSZ list, removing `n` elements from the front.

If `n` has multiple trailing zeros in binary format then we can reuse substantial portions of the tree when slicing, e.g. if `n = 4` we can cheapy clone the subtrees for indices `4`, `8`, `12`, `16` and so on, reordering them under new parent nodes.

This PR tries to implement this algorithm efficiently, by introducing the concept of a "level iterator" which iterates the `Arc`ed internal nodes at a given depth. It combines this with extensions to the tree `Builder` type which enable it to consume these internal nodes and build a tree.

There are new `proptest` tests added to extensively test the functionality, along with unit tests and benchmarks. Benchmarks show that `pop_front` is substantially faster than `pop_front_slow` when it is able to exploit node reuse, and no slower when it is unable to (when `n` has no trailing zeroes, i.e. because it is odd). 