### PR TITLE
Update `ethereum_hashing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["data-structures", "cryptography::cryptocurrencies", ]
 
 [dependencies]
 derivative = "2.2.0"
-ethereum_hashing = "0.6.0"
+ethereum_hashing = "0.7.0"
 ethereum_ssz = "0.5.0"
 ethereum_ssz_derive = "0.5.0"
 itertools = "0.10.3"

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -429,7 +429,7 @@ impl<T: Value + Send + Sync> Tree<T> {
                 }
             }
             Self::PackedLeaf(leaf) => leaf.tree_hash(),
-            Self::Zero(depth) => Hash256::from_slice(&ZERO_HASHES[*depth]),
+            Self::Zero(depth) => Hash256::from(ZERO_HASHES[*depth]),
             Self::Node { hash, left, right } => {
                 let read_lock = hash.read();
                 let existing_hash = *read_lock;


### PR DESCRIPTION
Update to new release of `ethereum_hashing` to take advantage of wider CPU support and potentially faster impl on non-x86_64 architectures (no more dynamic dispatch).