### PR TITLE
Remove outdated FIXME about MaxMap

### DIFF
--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -160,7 +160,6 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
     }
 
     fn max_index(&self) -> Option<usize> {
-        // FIXME(sproul): this is slow, make a wrapper type that tracks the max index
         self.keys().next_back()
     }
 


### PR DESCRIPTION
The FIXME is no longer relevant as the feature described has been implemented as `MaxMap` and is enabled by default