### PR TITLE
Interior mutability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ keywords = ["ethereum", "functional"]
 categories = ["data-structures", "cryptography::cryptocurrencies", ]
 
 [dependencies]
+arc-swap = "1.7.1"
 derivative = "2.2.0"
 ethereum_hashing = "0.6.0"
 ethereum_ssz = "0.5.0"
 ethereum_ssz_derive = "0.5.0"
 itertools = "0.10.3"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.1", features = ["arc_lock"] }
 rayon = "1.5.1"
 serde = { version = "1.0.0", features = ["derive"] }
 tree_hash = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod iter;
 pub mod leaf;
 pub mod level_iter;
 pub mod list;
+pub mod map_option;
 pub mod packed_leaf;
 mod repeat;
 pub mod serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod tests;
 pub mod tree;
 pub mod update_map;
 pub mod utils;
+pub mod value_ref;
 pub mod vector;
 
 pub use cow::Cow;
@@ -26,8 +27,10 @@ pub use leaf::Leaf;
 pub use list::List;
 pub use packed_leaf::PackedLeaf;
 pub use tree::Tree;
-pub use triomphe::Arc;
+// pub use triomphe::Arc;
+pub use std::sync::Arc; // FIXME(sproul)
 pub use update_map::UpdateMap;
+pub use value_ref::ValueRef;
 pub use vector::Vector;
 
 use ssz::{Decode, Encode};

--- a/src/map_option.rs
+++ b/src/map_option.rs
@@ -1,0 +1,60 @@
+use arc_swap::{access::Access, ArcSwap};
+use std::ops::Deref;
+use std::sync::Arc;
+
+pub struct MapOption<'a, F: Fn(Arc<T>) -> Option<&'a R>, T, R: 'a> {
+    accessor: F,
+    whole_value: &'a ArcSwap<T>,
+}
+
+impl<'a, F, T, R> MapOption<'a, F, T, R>
+where
+    F: Fn(Arc<T>) -> Option<&'a R>,
+{
+    pub fn new(value: &'a ArcSwap<T>, f: F) -> Self {
+        MapOption {
+            accessor: f,
+            whole_value: value,
+        }
+    }
+}
+
+pub struct MapOptionGuard<'a, T, R> {
+    value: Option<&'a R>,
+    parent: Arc<T>,
+}
+
+impl<'a, T, R> Deref for MapOptionGuard<'a, T, R> {
+    type Target = Option<&'a R>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+/*
+pub trait Access<T> {
+    type Guard: Deref<Target = T>;
+
+    // Required method
+    fn load(&self) -> Self::Guard;
+}
+*/
+
+impl<'a, F, T, R> Access<Option<&'a R>> for MapOption<'a, F, T, R>
+where
+    F: Fn(&'a Arc<T>) -> Option<&'a R>,
+{
+    type Guard = MapOptionGuard<'a, T, R>;
+
+    fn load(&self) -> Self::Guard {
+        let loaded_value: Arc<T> = self.whole_value.load_full();
+        let mut guard = MapOptionGuard {
+            value: None,
+            parent: loaded_value,
+        };
+        let value = (self.accessor)(&guard.parent);
+        guard.value = value;
+        guard
+    }
+}

--- a/src/tests/packed.rs
+++ b/src/tests/packed.rs
@@ -13,7 +13,7 @@ fn u64_packed_list_build_and_iter() {
         assert_eq!(vec, from_iter);
 
         for i in 0..len as usize {
-            assert_eq!(list.get(i), vec.get(i));
+            assert_eq!(list.get(i).as_deref(), vec.get(i));
         }
     }
 }
@@ -40,7 +40,7 @@ fn u64_packed_vector_build_and_iter() {
     assert_eq!(vec, from_iter);
 
     for i in 0..len as usize {
-        assert_eq!(vector.get(i), vec.get(i));
+        assert_eq!(vector.get(i).as_deref(), vec.get(i));
     }
 }
 
@@ -74,11 +74,11 @@ fn out_of_order_mutations() {
     for (i, v) in mutations {
         *list.get_mut(i).unwrap() = v;
         vec[i] = v;
-        assert_eq!(list.get(i), Some(&v));
+        assert_eq!(list.get(i).as_deref(), Some(&v));
 
         list.apply_updates().unwrap();
 
-        assert_eq!(list.get(i), Some(&v));
+        assert_eq!(list.get(i).as_deref(), Some(&v));
     }
 
     assert_eq!(list.to_vec(), vec);

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -183,7 +183,7 @@ where
                 assert_eq!(list.len(), spec.len())
             }
             Op::Get(index) => {
-                assert_eq!(list.get(index), spec.get(index));
+                assert_eq!(list.get(index).as_deref(), spec.get(index));
             }
             Op::Set(index, value) => {
                 let res = list.get_mut(index).map(|elem| *elem = value.clone());
@@ -269,7 +269,7 @@ where
                 assert_eq!(vect.len(), spec.len())
             }
             Op::Get(index) => {
-                assert_eq!(vect.get(index), spec.get(index));
+                assert_eq!(vect.get(index).as_deref(), spec.get(index));
             }
             Op::Set(index, value) => {
                 let res = vect.get_mut(index).map(|elem| *elem = value.clone());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::{Arc, UpdateMap};
 use arbitrary::Arbitrary;
+use arc_swap::ArcSwap;
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use tree_hash::{Hash256, TreeHash, TreeHashType};
@@ -108,6 +109,26 @@ pub fn arb_rwlock<'a, T: Arbitrary<'a>>(
     u: &mut arbitrary::Unstructured<'a>,
 ) -> arbitrary::Result<RwLock<T>> {
     T::arbitrary(u).map(RwLock::new)
+}
+
+pub fn arb_arc_rwlock<'a, T: Arbitrary<'a>>(
+    u: &mut arbitrary::Unstructured<'a>,
+) -> arbitrary::Result<std::sync::Arc<RwLock<T>>> {
+    T::arbitrary(u).map(RwLock::new).map(std::sync::Arc::new)
+}
+
+pub fn arb_arc_swap<'a, T: Arbitrary<'a>>(
+    u: &mut arbitrary::Unstructured<'a>,
+) -> arbitrary::Result<ArcSwap<T>> {
+    T::arbitrary(u).map(std::sync::Arc::new).map(ArcSwap::new)
+}
+
+pub fn partial_eq_rwlock<'a, T: PartialEq>(x: &RwLock<T>, y: &RwLock<T>) -> bool {
+    *x.read() == *y.read()
+}
+
+pub fn partial_eq_arc_swap<'a, T: PartialEq>(x: &ArcSwap<T>, y: &ArcSwap<T>) -> bool {
+    *x.load() == *y.load()
 }
 
 #[cfg(test)]

--- a/src/value_ref.rs
+++ b/src/value_ref.rs
@@ -1,0 +1,22 @@
+use parking_lot::MappedRwLockReadGuard;
+use std::ops::Deref;
+
+/// Reference to a value within a List or Vector.
+#[derive(Debug)]
+pub enum ValueRef<'a, T> {
+    /// The value is present in the `updates` map and is waiting to be applied.
+    Pending(MappedRwLockReadGuard<'a, T>),
+    /// The value is present in the tree.
+    Applied(&'a T),
+}
+
+impl<'a, T> Deref for ValueRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Pending(guard) => guard.deref(),
+            Self::Applied(reference) => reference,
+        }
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,11 +1,11 @@
-use crate::interface::{ImmList, Interface, MutList};
+use crate::interface::{GetResult, ImmList, Interface, MutList};
 use crate::interface_iter::InterfaceIter;
 use crate::iter::Iter;
 use crate::level_iter::LevelIter;
 use crate::tree::RebaseAction;
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc_swap, partial_eq_arc_swap, Length};
-use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value, ValueRef};
+use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
 use arc_swap::ArcSwap;
 use derivative::Derivative;
@@ -93,7 +93,7 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     }
 
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
-    pub fn get(&self, index: usize) -> Option<ValueRef<T>> {
+    pub fn get(&self, index: usize) -> Option<GetResult<T>> {
         self.interface.get(index)
     }
 
@@ -193,7 +193,9 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> From<Vector<T, N, U>> for List<T, N
 }
 
 impl<T: Value, N: Unsigned> ImmList<T> for VectorInner<T, N> {
-    fn get(&self, index: usize) -> Option<&T> {
+    fn get(&self, index: usize) -> Option<GetResult<T>> {
+        None
+        /* FIXME(sproul)
         if index < self.len().as_usize() {
             self.tree
                 .load()
@@ -201,6 +203,7 @@ impl<T: Value, N: Unsigned> ImmList<T> for VectorInner<T, N> {
         } else {
             None
         }
+        */
     }
 
     fn len(&self) -> Length {


### PR DESCRIPTION
This is an attempt to remove the need for mutability in `TreeHash`, by using `ArcSwap` and `RwLock` to handle the pending updates.

Alternative to these other 2 approaches which hit dead ends:

- https://github.com/sigp/tree_hash/pull/23
- https://github.com/sigp/tree_hash/pull/24