### PR TITLE
Switch from derivative to educe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ethereum", "functional"]
 categories = ["data-structures", "cryptography::cryptocurrencies", ]
 
 [dependencies]
-derivative = "2.2.0"
+educe = "0.6.0"
 ethereum_hashing = "0.7.0"
 ethereum_ssz = "0.7.0"
 ethereum_ssz_derive = "0.7.0"

--- a/src/leaf.rs
+++ b/src/leaf.rs
@@ -3,14 +3,14 @@ use crate::{
     Arc,
 };
 use arbitrary::Arbitrary;
-use derivative::Derivative;
+use educe::Educe;
 use parking_lot::RwLock;
 use tree_hash::Hash256;
 
-#[derive(Debug, Derivative, Arbitrary)]
-#[derivative(PartialEq, Hash)]
+#[derive(Debug, Educe, Arbitrary)]
+#[educe(PartialEq, Hash)]
 pub struct Leaf<T> {
-    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    #[educe(PartialEq(ignore), Hash(ignore))]
     #[arbitrary(with = arb_rwlock)]
     pub hash: RwLock<Hash256>,
     #[arbitrary(with = arb_arc)]

--- a/src/list.rs
+++ b/src/list.rs
@@ -9,7 +9,7 @@ use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, compute_level, int_log, opt_packing_depth, updated_length, Length};
 use crate::{Arc, Cow, Error, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
-use derivative::Derivative;
+use educe::Educe;
 use itertools::process_results;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode, SszEncoder, TryFromIter, BYTES_PER_LENGTH_OFFSET};
@@ -19,16 +19,16 @@ use tree_hash::{Hash256, PackedEncoding, TreeHash};
 use typenum::Unsigned;
 use vec_map::VecMap;
 
-#[derive(Debug, Clone, Derivative, Arbitrary)]
-#[derivative(PartialEq(bound = "T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq"))]
+#[derive(Debug, Clone, Educe, Arbitrary)]
+#[educe(PartialEq(bound(T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq)))]
 #[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value")]
 #[arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T> + PartialEq")]
 pub struct List<T: Value, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
     pub(crate) interface: Interface<T, ListInner<T, N>, U>,
 }
 
-#[derive(Debug, Clone, Derivative, Arbitrary)]
-#[derivative(PartialEq(bound = "T: Value, N: Unsigned"))]
+#[derive(Debug, Clone, Educe, Arbitrary)]
+#[educe(PartialEq(bound(T: Value, N: Unsigned)))]
 #[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")]
 pub struct ListInner<T: Value, N: Unsigned> {
     #[arbitrary(with = arb_arc)]

--- a/src/packed_leaf.rs
+++ b/src/packed_leaf.rs
@@ -1,14 +1,14 @@
 use crate::{utils::arb_rwlock, Error, UpdateMap};
 use arbitrary::Arbitrary;
-use derivative::Derivative;
+use educe::Educe;
 use parking_lot::RwLock;
 use std::ops::ControlFlow;
 use tree_hash::{Hash256, TreeHash, BYTES_PER_CHUNK};
 
-#[derive(Debug, Derivative, Arbitrary)]
-#[derivative(PartialEq, Hash)]
+#[derive(Debug, Educe, Arbitrary)]
+#[educe(PartialEq, Hash)]
 pub struct PackedLeaf<T: TreeHash + Clone> {
-    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    #[educe(PartialEq(ignore), Hash(ignore))]
     #[arbitrary(with = arb_rwlock)]
     pub hash: RwLock<Hash256>,
     pub(crate) values: Vec<T>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,20 +1,20 @@
 use crate::utils::{arb_arc, arb_rwlock, opt_hash, opt_packing_depth, opt_packing_factor, Length};
 use crate::{Arc, Error, Leaf, PackedLeaf, UpdateMap, Value};
 use arbitrary::Arbitrary;
-use derivative::Derivative;
+use educe::Educe;
 use ethereum_hashing::{hash32_concat, ZERO_HASHES};
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 use tree_hash::Hash256;
 
-#[derive(Debug, Derivative, Arbitrary)]
-#[derivative(PartialEq, Hash)]
+#[derive(Debug, Educe, Arbitrary)]
+#[educe(PartialEq(bound(T: Value)), Hash)]
 pub enum Tree<T: Value> {
     Leaf(Leaf<T>),
     PackedLeaf(PackedLeaf<T>),
     Node {
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        #[educe(PartialEq(ignore), Hash(ignore))]
         #[arbitrary(with = arb_rwlock)]
         hash: RwLock<Hash256>,
         #[arbitrary(with = arb_arc)]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -7,7 +7,7 @@ use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, Length};
 use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value};
 use arbitrary::Arbitrary;
-use derivative::Derivative;
+use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode, SszEncoder, TryFromIter, BYTES_PER_LENGTH_OFFSET};
 use std::collections::BTreeMap;
@@ -17,8 +17,8 @@ use tree_hash::{Hash256, PackedEncoding};
 use typenum::Unsigned;
 use vec_map::VecMap;
 
-#[derive(Debug, Derivative, Clone, Serialize, Deserialize, Arbitrary)]
-#[derivative(PartialEq(bound = "T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq"))]
+#[derive(Debug, Educe, Clone, Serialize, Deserialize, Arbitrary)]
+#[educe(PartialEq(bound(T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq)))]
 #[serde(try_from = "List<T, N, U>")]
 #[serde(into = "List<T, N, U>")]
 #[serde(bound(serialize = "T: Value + Serialize, N: Unsigned, U: UpdateMap<T>"))]
@@ -29,8 +29,8 @@ pub struct Vector<T: Value, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
     pub(crate) interface: Interface<T, VectorInner<T, N>, U>,
 }
 
-#[derive(Debug, Derivative, Clone, Arbitrary)]
-#[derivative(PartialEq(bound = "T: Value, N: Unsigned"))]
+#[derive(Debug, Educe, Clone, Arbitrary)]
+#[educe(PartialEq(bound(T: Value, N: Unsigned)))]
 #[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")]
 pub struct VectorInner<T: Value, N: Unsigned> {
     #[arbitrary(with = arb_arc)]


### PR DESCRIPTION
Derivative is unmaintained (see https://rustsec.org/advisories/RUSTSEC-2024-0388), so I think we should switch to `educe` across all of our crates.