### PR TITLE
Bump SSZ version to `0.8.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ alloy-primitives = { version = "0.8.0", features = ["arbitrary"] }
 
 
 [dev-dependencies]
-ssz_types = "0.8.0"
+ssz_types = "0.9.0"
 proptest = "1.0.0"
 tree_hash_derive = "0.8.0"
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ readme = "README.md"
 repository = "https://github.com/sigp/milhouse"
 documentation = "https://docs.rs/milhouse"
 keywords = ["ethereum", "functional"]
-categories = ["data-structures", "cryptography::cryptocurrencies", ]
+categories = ["data-structures", "cryptography::cryptocurrencies"]
 
 [dependencies]
 educe = "0.6.0"
 ethereum_hashing = "0.7.0"
-ethereum_ssz = "0.7.0"
-ethereum_ssz_derive = "0.7.0"
+ethereum_ssz = "0.8.0"
+ethereum_ssz_derive = "0.8.0"
 itertools = "0.13.0"
 parking_lot = "0.12.1"
 rayon = "1.5.1"


### PR DESCRIPTION
This coincides with a new release of the SSZ crates: https://github.com/sigp/ethereum_ssz/releases/tag/v0.8.1