### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milhouse"
-version = "0.3.0"
+version = "0.4.0"
 description = "Persistent binary merkle tree"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
New minor release for breaking change:

- Bump `ethereum_ssz` to `0.8`