### PR TITLE
Bump versions of various `sigp` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,18 @@ readme = "README.md"
 repository = "https://github.com/sigp/milhouse"
 documentation = "https://docs.rs/milhouse"
 keywords = ["ethereum", "functional"]
-categories = ["data-structures", "cryptography::cryptocurrencies", ]
+categories = ["data-structures", "cryptography::cryptocurrencies"]
 
 [dependencies]
 educe = "0.6.0"
 ethereum_hashing = "0.7.0"
-ethereum_ssz = "0.7.0"
-ethereum_ssz_derive = "0.7.0"
+ethereum_ssz = "0.8"
+ethereum_ssz_derive = "0.8"
 itertools = "0.13.0"
 parking_lot = "0.12.1"
 rayon = "1.5.1"
 serde = { version = "1.0.0", features = ["derive"] }
-tree_hash = "0.8.0"
+tree_hash = "0.9"
 triomphe = "0.1.5"
 typenum = "1.14.0"
 vec_map = "0.8.2"
@@ -29,9 +29,9 @@ alloy-primitives = { version = "0.8.0", features = ["arbitrary"] }
 
 
 [dev-dependencies]
-ssz_types = "0.8.0"
+ssz_types = "0.10"
 proptest = "1.0.0"
-tree_hash_derive = "0.8.0"
+tree_hash_derive = "0.9"
 criterion = "0.5"
 
 [features]


### PR DESCRIPTION
Bumps versions for some `sigp` crates.

Related to this effort: https://github.com/sigp/lighthouse/pull/6609