### PR TITLE
Abstract over `U: UpdateMap` more

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -336,13 +336,13 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     }
 }
 
-impl<T: Value, N: Unsigned> Default for List<T, N> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Default for List<T, N, U> {
     fn default() -> Self {
         Self::empty()
     }
 }
 
-impl<T: Value + Send + Sync, N: Unsigned> TreeHash for List<T, N> {
+impl<T: Value + Send + Sync, N: Unsigned, U: UpdateMap<T>> TreeHash for List<T, N, U> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::List
     }
@@ -404,7 +404,7 @@ where
 }
 
 // FIXME: duplicated from `ssz::encode::impl_for_vec`
-impl<T: Value, N: Unsigned> Encode for List<T, N> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Encode for List<T, N, U> {
     fn is_ssz_fixed_len() -> bool {
         false
     }
@@ -438,10 +438,11 @@ impl<T: Value, N: Unsigned> Encode for List<T, N> {
     }
 }
 
-impl<T, N> TryFromIter<T> for List<T, N>
+impl<T, N, U> TryFromIter<T> for List<T, N, U>
 where
     T: Value,
     N: Unsigned,
+    U: UpdateMap<T>,
 {
     type Error = Error;
 
@@ -453,10 +454,11 @@ where
     }
 }
 
-impl<T, N> Decode for List<T, N>
+impl<T, N, U> Decode for List<T, N, U>
 where
     T: Value,
     N: Unsigned,
+    U: UpdateMap<T>,
 {
     fn is_ssz_fixed_len() -> bool {
         false

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -238,7 +238,7 @@ where
     }
 }
 
-impl<T: Default + Value, N: Unsigned> Default for Vector<T, N> {
+impl<T: Default + Value, N: Unsigned, U: UpdateMap<T>> Default for Vector<T, N, U> {
     fn default() -> Self {
         Self::from_elem(T::default()).unwrap_or_else(|e| {
             panic!(
@@ -250,7 +250,7 @@ impl<T: Default + Value, N: Unsigned> Default for Vector<T, N> {
     }
 }
 
-impl<T: Value + Send + Sync, N: Unsigned> tree_hash::TreeHash for Vector<T, N> {
+impl<T: Value + Send + Sync, N: Unsigned, U: UpdateMap<T>> tree_hash::TreeHash for Vector<T, N, U> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
     }
@@ -270,10 +270,11 @@ impl<T: Value + Send + Sync, N: Unsigned> tree_hash::TreeHash for Vector<T, N> {
     }
 }
 
-impl<T, N> TryFromIter<T> for Vector<T, N>
+impl<T, N, U> TryFromIter<T> for Vector<T, N, U>
 where
     T: Value,
     N: Unsigned,
+    U: UpdateMap<T>,
 {
     type Error = Error;
 
@@ -295,7 +296,7 @@ impl<'a, T: Value, N: Unsigned, U: UpdateMap<T>> IntoIterator for &'a Vector<T, 
 }
 
 // FIXME: duplicated from `ssz::encode::impl_for_vec`
-impl<T: Value, N: Unsigned> Encode for Vector<T, N> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Encode for Vector<T, N, U> {
     fn is_ssz_fixed_len() -> bool {
         <T as Encode>::is_ssz_fixed_len()
     }
@@ -337,7 +338,7 @@ impl<T: Value, N: Unsigned> Encode for Vector<T, N> {
     }
 }
 
-impl<T: Value, N: Unsigned> Decode for Vector<T, N> {
+impl<T: Value, N: Unsigned, U: UpdateMap<T>> Decode for Vector<T, N, U> {
     fn is_ssz_fixed_len() -> bool {
         <T as Decode>::is_ssz_fixed_len()
     }


### PR DESCRIPTION
We had only partly abstracted over the type `U` used for storing pending updates to lists/vectors. This PR updates several of the trait implementations so that they work with any choice of `U`, not just the default `VecMap`.

It may be advantageous to use a different map type now that the validator set has grown. The size of a `VecMap` is `O(largest index)`, so I suspect we are allocating _a lot_ of very large vecs on networks with millions of validators (mainnet, Holesky). A `BTreeMap` may be more efficient in terms of speed and memory usage at this point. I will do some benchmarks with Lighthouse against this branch before merging.