### PR TITLE
Test serde deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ssz_types = "0.10"
 proptest = "1.0.0"
 tree_hash_derive = "0.9"
 criterion = "0.5"
+serde_json = "1.0.0"
 
 [features]
 debug = []

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,4 +6,5 @@ mod packed;
 mod pop_front;
 mod proptest;
 mod repeat;
+mod serde;
 mod size_of;

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -1,0 +1,32 @@
+use crate::{List, Vector};
+use typenum::U4;
+
+#[test]
+fn deserialize_list_invalid_length() {
+    let json = serde_json::json!([1, 2, 3, 4, 5]);
+    let result: Result<List<u64, U4>, _> = serde_json::from_value(json);
+    assert!(result.is_err());
+
+    let json = serde_json::json!([1, 2, 3]);
+    let result: Result<List<u64, U4>, _> = serde_json::from_value(json);
+    assert!(result.is_ok());
+
+    let json = serde_json::json!([1, 2, 3, 4]);
+    let result: Result<List<u64, U4>, _> = serde_json::from_value(json);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn deserialize_vector_invalid_length() {
+    let json = serde_json::json!([1, 2, 3, 4, 5]);
+    let result: Result<Vector<u64, U4>, _> = serde_json::from_value(json);
+    assert!(result.is_err());
+
+    let json = serde_json::json!([1, 2, 3]);
+    let result: Result<Vector<u64, U4>, _> = serde_json::from_value(json);
+    assert!(result.is_err());
+
+    let json = serde_json::json!([1, 2, 3, 4]);
+    let result: Result<Vector<u64, U4>, _> = serde_json::from_value(json);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Inspired by @pawanjay176's PR to `ssz_types`, these tests ensure that `milhouse`'s `Deserialize` implementations maintain length invariants. They do!

See also:

- https://github.com/sigp/ssz_types/pull/43