### PR TITLE
Release v0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milhouse"
-version = "0.5.0"
+version = "0.5.1"
 description = "Persistent binary merkle tree"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
New release, primarily for `U: UpdateMap` abstractions.

Required for a LH memory fix:

- https://github.com/sigp/lighthouse/pull/6820