### PR TITLE
Implement `intra_rebase` to reuse identical subtrees

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,7 @@ pub enum Error {
     LevelIterPendingUpdates,
     IntraRebaseZeroHash,
     IntraRebaseZeroDepth,
+    IntraRebaseRepeatVisit,
 }
 
 impl Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
     BulkUpdateUnclean,
     CowMissingEntry,
     LevelIterPendingUpdates,
+    IntraRebaseZeroHash,
+    IntraRebaseZeroDepth,
 }
 
 impl Display for Error {

--- a/src/list.rs
+++ b/src/list.rs
@@ -4,7 +4,7 @@ use crate::interface_iter::{InterfaceIter, InterfaceIterCow};
 use crate::iter::Iter;
 use crate::level_iter::{LevelIter, LevelNode};
 use crate::serde::ListVisitor;
-use crate::tree::RebaseAction;
+use crate::tree::{IntraRebaseAction, RebaseAction};
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, compute_level, int_log, opt_packing_depth, updated_length, Length};
 use crate::{Arc, Cow, Error, Tree, UpdateMap, Value};
@@ -13,7 +13,7 @@ use educe::Educe;
 use itertools::process_results;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode, SszEncoder, TryFromIter, BYTES_PER_LENGTH_OFFSET};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use tree_hash::{Hash256, PackedEncoding, TreeHash};
 use typenum::Unsigned;
@@ -331,6 +331,18 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
                 self.interface.backing.tree = replacement;
             }
             _ => (),
+        }
+        Ok(())
+    }
+
+    pub fn intra_rebase(&mut self) -> Result<(), Error> {
+        let mut known_subtrees = HashMap::new();
+        if let IntraRebaseAction::Replace(new_tree) = Tree::intra_rebase(
+            &self.interface.backing.tree,
+            &mut known_subtrees,
+            self.interface.backing.depth,
+        )? {
+            self.interface.backing.tree = new_tree;
         }
         Ok(())
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2,7 +2,7 @@ use crate::interface::{ImmList, Interface, MutList};
 use crate::interface_iter::InterfaceIter;
 use crate::iter::Iter;
 use crate::level_iter::LevelIter;
-use crate::tree::RebaseAction;
+use crate::tree::{IntraRebaseAction, RebaseAction};
 use crate::update_map::MaxMap;
 use crate::utils::{arb_arc, Length};
 use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value};
@@ -10,7 +10,7 @@ use arbitrary::Arbitrary;
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode, SszEncoder, TryFromIter, BYTES_PER_LENGTH_OFFSET};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::marker::PhantomData;
 use tree_hash::{Hash256, PackedEncoding};
@@ -158,6 +158,18 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
                 self.interface.backing.tree = replacement;
             }
             _ => (),
+        }
+        Ok(())
+    }
+
+    pub fn intra_rebase(&mut self) -> Result<(), Error> {
+        let mut known_subtrees = HashMap::new();
+        if let IntraRebaseAction::Replace(new_tree) = Tree::intra_rebase(
+            &self.interface.backing.tree,
+            &mut known_subtrees,
+            self.interface.backing.depth,
+        )? {
+            self.interface.backing.tree = new_tree;
         }
         Ok(())
     }


### PR DESCRIPTION
While debugging high memory usage on Holesky, we found that the changing `inactivity_scores` were occupying a large amount of RAM: around 70MB of new data each epoch boundary. See:

- https://github.com/sigp/lighthouse/issues/7053#issuecomment-2693115614

With this change, we can reduce it down to 4MB, with a rebase op taking only 42ms.

The `intra_rebase` implementation is a recursive depth-first tree traversal. It's similar to `rebase`, but a bit simpler.