### PR TITLE
Make intra_rebase more user friendly

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -334,8 +334,15 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
         }
         Ok(())
     }
+}
 
+impl<T: Value + Send + Sync, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     pub fn intra_rebase(&mut self) -> Result<(), Error> {
+        // We need to be fully hashed in order to intra-rebase. To avoid putting this burden on the
+        // caller, just do it here. If we're already fully-hashed this should be quick.
+        self.apply_updates()?;
+        self.tree_hash_root();
+
         let mut known_subtrees = HashMap::new();
         if let IntraRebaseAction::Replace(new_tree) = Tree::intra_rebase(
             &self.interface.backing.tree,

--- a/src/tests/proptest/operations.rs
+++ b/src/tests/proptest/operations.rs
@@ -256,10 +256,12 @@ where
                 }
             }
             Op::IntraRebase => {
-                list.apply_updates().unwrap();
-                list.tree_hash_root();
                 let mut new_list = list.clone();
                 new_list.intra_rebase().unwrap();
+
+                list.apply_updates().unwrap();
+                list.tree_hash_root();
+
                 assert_eq!(new_list, *list);
                 *list = new_list;
             }
@@ -342,10 +344,12 @@ where
                 }
             }
             Op::IntraRebase => {
-                vect.apply_updates().unwrap();
-                vect.tree_hash_root();
                 let mut new_vect = vect.clone();
                 new_vect.intra_rebase().unwrap();
+
+                vect.apply_updates().unwrap();
+                vect.tree_hash_root();
+
                 assert_eq!(new_vect, *vect);
                 *vect = new_vect;
             }


### PR DESCRIPTION
Remove pre-conditions from `intra_rebase` about applying updates and tree hashing. We can just do these inline because we have a mutable reference.

This fixes a bug found by @eserilev in my first impl of intra_rebase in LH, which forgot to tree hash before calling the method :man_facepalming: 