### PR TITLE
Put arbitrary crate behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ triomphe = "0.1.5"
 typenum = "1.14.0"
 vec_map = "0.8.2"
 smallvec = "1.8.0"
-arbitrary = { version = "1.2.3", optional = true }
+arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
 alloy-primitives = { version = "1.0.0" }
 
 
@@ -36,8 +36,8 @@ criterion = "0.5"
 serde_json = "1.0.0"
 
 [features]
-default = ["arbitrary"]
-arbitrary = ["arbitrary/derive", "alloy-primitives/arbitrary"]
+default = []
+arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
 debug = []
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ criterion = "0.5"
 serde_json = "1.0.0"
 
 [features]
-default = []
 arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
 debug = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ triomphe = "0.1.5"
 typenum = "1.14.0"
 vec_map = "0.8.2"
 smallvec = "1.8.0"
-arbitrary = { version = "1.2.3", features = ["derive"] }
-alloy-primitives = { version = "1.0.0", features = ["arbitrary"] }
+arbitrary = { version = "1.2.3", optional = true }
+alloy-primitives = { version = "1.0.0" }
 
 
 [dev-dependencies]
@@ -36,6 +36,8 @@ criterion = "0.5"
 serde_json = "1.0.0"
 
 [features]
+default = ["arbitrary"]
+arbitrary = ["arbitrary/derive", "alloy-primitives/arbitrary"]
 debug = []
 
 [[bench]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ typenum = "1.17.0"
 
 [dependencies.milhouse]
 path = ".."
+features = ["arbitrary"]
 
 [[bin]]
 name = "builder"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -6,7 +6,6 @@ use crate::{
     iter::Iter,
     Cow, Error, Value,
 };
-use arbitrary::Arbitrary;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use tree_hash::Hash256;
@@ -35,7 +34,8 @@ pub trait MutList<T: Value>: ImmList<T> {
     ) -> Result<(), Error>;
 }
 
-#[derive(Debug, PartialEq, Clone, Arbitrary)]
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Interface<T, B, U>
 where
     T: Value,

--- a/src/leaf.rs
+++ b/src/leaf.rs
@@ -1,19 +1,16 @@
-use crate::{
-    utils::{arb_arc, arb_rwlock},
-    Arc,
-};
-use arbitrary::Arbitrary;
+use crate::Arc;
 use educe::Educe;
 use parking_lot::RwLock;
 use tree_hash::Hash256;
 
-#[derive(Debug, Educe, Arbitrary)]
+#[derive(Debug, Educe)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[educe(PartialEq, Hash)]
 pub struct Leaf<T> {
     #[educe(PartialEq(ignore), Hash(ignore))]
-    #[arbitrary(with = arb_rwlock)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_rwlock))]
     pub hash: RwLock<Hash256>,
-    #[arbitrary(with = arb_arc)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_arc))]
     pub value: Arc<T>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use tree_hash::TreeHash;
 /// We limit trees to 2^63 elements so we can avoid overflow when calculating 2^depth.
 pub const MAX_TREE_DEPTH: usize = u64::BITS as usize - 1;
 
-pub const MAX_TREE_LENGTH: usize = 1 << MAX_TREE_DEPTH;
+pub const MAX_TREE_LENGTH: u64 = 1 << MAX_TREE_DEPTH;
 
 #[cfg(feature = "debug")]
 pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use tree_hash::TreeHash;
 /// We limit trees to 2^63 elements so we can avoid overflow when calculating 2^depth.
 pub const MAX_TREE_DEPTH: usize = u64::BITS as usize - 1;
 
-pub const MAX_TREE_LENGTH: u64 = 1 << MAX_TREE_DEPTH;
+pub const MAX_TREE_LENGTH: usize = 1 << MAX_TREE_DEPTH;
 
 #[cfg(feature = "debug")]
 pub trait Value: Encode + Decode + TreeHash + PartialEq + Clone + std::fmt::Debug {}

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,8 +6,9 @@ use crate::level_iter::{LevelIter, LevelNode};
 use crate::serde::ListVisitor;
 use crate::tree::{IntraRebaseAction, RebaseAction};
 use crate::update_map::MaxMap;
-use crate::utils::{arb_arc, compute_level, int_log, opt_packing_depth, updated_length, Length};
+use crate::utils::{compute_level, int_log, opt_packing_depth, updated_length, Length};
 use crate::{Arc, Cow, Error, Tree, UpdateMap, Value};
+#[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 use educe::Educe;
 use itertools::process_results;
@@ -18,25 +19,32 @@ use std::marker::PhantomData;
 use tree_hash::{Hash256, PackedEncoding, TreeHash};
 use typenum::Unsigned;
 use vec_map::VecMap;
-
-#[derive(Debug, Clone, Educe, Arbitrary)]
+#[derive(Debug, Clone, Educe)]
 #[educe(PartialEq(bound(T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq)))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value")]
-#[arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T> + PartialEq")]
+#[cfg_attr(
+    feature = "arbitrary",
+    derive(Arbitrary),
+    arbitrary(bound = "T: Arbitrary<'arbitrary> + Value"),
+    arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T> + PartialEq")
+)]
 pub struct List<T: Value, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
     pub(crate) interface: Interface<T, ListInner<T, N>, U>,
 }
 
-#[derive(Debug, Clone, Educe, Arbitrary)]
+#[derive(Debug, Clone, Educe)]
 #[educe(PartialEq(bound(T: Value, N: Unsigned)))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")]
+#[cfg_attr(
+    feature = "arbitrary",
+    derive(Arbitrary),
+    arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")
+)]
 pub struct ListInner<T: Value, N: Unsigned> {
-    #[arbitrary(with = arb_arc)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_arc))]
     pub(crate) tree: Arc<Tree<T>>,
     pub(crate) length: Length,
     pub(crate) depth: usize,
     pub(crate) packing_depth: usize,
-    #[arbitrary(default)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     _phantom: PhantomData<N>,
 }
 

--- a/src/packed_leaf.rs
+++ b/src/packed_leaf.rs
@@ -1,15 +1,15 @@
-use crate::{utils::arb_rwlock, Error, UpdateMap};
-use arbitrary::Arbitrary;
+use crate::{Error, UpdateMap};
 use educe::Educe;
 use parking_lot::RwLock;
 use std::ops::ControlFlow;
 use tree_hash::{Hash256, TreeHash, BYTES_PER_CHUNK};
 
-#[derive(Debug, Educe, Arbitrary)]
+#[derive(Debug, Educe)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[educe(PartialEq, Hash)]
 pub struct PackedLeaf<T: TreeHash + Clone> {
     #[educe(PartialEq(ignore), Hash(ignore))]
-    #[arbitrary(with = arb_rwlock)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_rwlock))]
     pub hash: RwLock<Hash256>,
     pub(crate) values: Vec<T>,
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,5 @@
-use crate::utils::{arb_arc, arb_rwlock, opt_hash, opt_packing_depth, opt_packing_factor, Length};
+use crate::utils::{opt_hash, opt_packing_depth, opt_packing_factor, Length};
 use crate::{Arc, Error, Leaf, PackedLeaf, UpdateMap, Value};
-use arbitrary::Arbitrary;
 use educe::Educe;
 use ethereum_hashing::{hash32_concat, ZERO_HASHES};
 use parking_lot::RwLock;
@@ -9,18 +8,19 @@ use std::collections::HashMap;
 use std::ops::ControlFlow;
 use tree_hash::Hash256;
 
-#[derive(Debug, Educe, Arbitrary)]
+#[derive(Debug, Educe)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[educe(PartialEq(bound(T: Value)), Hash)]
 pub enum Tree<T: Value> {
     Leaf(Leaf<T>),
     PackedLeaf(PackedLeaf<T>),
     Node {
         #[educe(PartialEq(ignore), Hash(ignore))]
-        #[arbitrary(with = arb_rwlock)]
+        #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_rwlock))]
         hash: RwLock<Hash256>,
-        #[arbitrary(with = arb_arc)]
+        #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_arc))]
         left: Arc<Self>,
-        #[arbitrary(with = arb_arc)]
+        #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_arc))]
         right: Arc<Self>,
     },
     Zero(usize),

--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -1,6 +1,5 @@
 use crate::cow::{BTreeCow, Cow, VecCow};
 use crate::utils::max_btree_index;
-use arbitrary::Arbitrary;
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::ops::ControlFlow;
 use vec_map::VecMap;
@@ -168,10 +167,14 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Arbitrary)]
-#[arbitrary(bound = "M: Default")]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "arbitrary",
+    derive(arbitrary::Arbitrary),
+    arbitrary(bound = "M: Default")
+)]
 pub struct MaxMap<M> {
-    #[arbitrary(default)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     inner: M,
     max_key: usize,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,8 @@
 use crate::{Arc, UpdateMap};
+#[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use tree_hash::{Hash256, TreeHash, TreeHashType};
-
 /// Type to abstract over whether `T` is wrapped in an `Arc` or not.
 #[derive(Debug)]
 pub enum MaybeArced<T> {
@@ -21,7 +20,8 @@ impl<T> MaybeArced<T> {
 }
 
 /// Length type, to avoid confusion with depth and other `usize` parameters.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Arbitrary)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Length(pub usize);
 
 impl Length {
@@ -98,16 +98,18 @@ pub fn opt_hash(
     hashes?.get(&(depth, prefix)).copied()
 }
 
+#[cfg(feature = "arbitrary")]
 pub fn arb_arc<'a, T: Arbitrary<'a>>(
     u: &mut arbitrary::Unstructured<'a>,
 ) -> arbitrary::Result<Arc<T>> {
     T::arbitrary(u).map(Arc::new)
 }
 
+#[cfg(feature = "arbitrary")]
 pub fn arb_rwlock<'a, T: Arbitrary<'a>>(
     u: &mut arbitrary::Unstructured<'a>,
-) -> arbitrary::Result<RwLock<T>> {
-    T::arbitrary(u).map(RwLock::new)
+) -> arbitrary::Result<parking_lot::RwLock<T>> {
+    T::arbitrary(u).map(parking_lot::RwLock::new)
 }
 
 #[cfg(test)]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -4,8 +4,9 @@ use crate::iter::Iter;
 use crate::level_iter::LevelIter;
 use crate::tree::{IntraRebaseAction, RebaseAction};
 use crate::update_map::MaxMap;
-use crate::utils::{arb_arc, Length};
+use crate::utils::Length;
 use crate::{Arc, Cow, Error, List, Tree, UpdateMap, Value};
+#[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 use educe::Educe;
 use serde::{Deserialize, Serialize};
@@ -17,27 +18,35 @@ use tree_hash::{Hash256, PackedEncoding, TreeHash};
 use typenum::Unsigned;
 use vec_map::VecMap;
 
-#[derive(Debug, Educe, Clone, Serialize, Deserialize, Arbitrary)]
+#[derive(Debug, Educe, Clone, Serialize, Deserialize)]
 #[educe(PartialEq(bound(T: Value, N: Unsigned, U: UpdateMap<T> + PartialEq)))]
 #[serde(try_from = "List<T, N, U>")]
 #[serde(into = "List<T, N, U>")]
 #[serde(bound(serialize = "T: Value + Serialize, N: Unsigned, U: UpdateMap<T>"))]
 #[serde(bound(deserialize = "T: Value + Deserialize<'de>, N: Unsigned, U: UpdateMap<T>"))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value")]
-#[arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T>")]
+#[cfg_attr(
+    feature = "arbitrary",
+    derive(Arbitrary),
+    arbitrary(bound = "T: Arbitrary<'arbitrary> + Value"),
+    arbitrary(bound = "N: Unsigned, U: Arbitrary<'arbitrary> + UpdateMap<T>")
+)]
 pub struct Vector<T: Value, N: Unsigned, U: UpdateMap<T> = MaxMap<VecMap<T>>> {
     pub(crate) interface: Interface<T, VectorInner<T, N>, U>,
 }
 
-#[derive(Debug, Educe, Clone, Arbitrary)]
+#[derive(Debug, Educe, Clone)]
 #[educe(PartialEq(bound(T: Value, N: Unsigned)))]
-#[arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")]
+#[cfg_attr(
+    feature = "arbitrary",
+    derive(Arbitrary),
+    arbitrary(bound = "T: Arbitrary<'arbitrary> + Value, N: Unsigned")
+)]
 pub struct VectorInner<T: Value, N: Unsigned> {
-    #[arbitrary(with = arb_arc)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(with = crate::utils::arb_arc))]
     pub(crate) tree: Arc<Tree<T>>,
     pub(crate) depth: usize,
     packing_depth: usize,
-    #[arbitrary(default)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     _phantom: PhantomData<N>,
 }
 


### PR DESCRIPTION
This is part of an effort to feature gate the `arbitrary` crate from lighthouse's `types` crate. Will open a PR in the Lighthouse repo tomorrow with these changes: https://github.com/risc0-labs/lighthouse/tree/ec2/arbitrary-unstable