### PR TITLE
Fix Clippy lints for Rust 1.88

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,7 +45,7 @@ impl<T: Value> Builder<T> {
 
         // Fold the nodes on the left of this node into it, and then push that node to the stack.
         let mut new_stack_top = if let Some(packing_factor) = self.packing_factor {
-            if index % packing_factor == 0 {
+            if index.is_multiple_of(packing_factor) {
                 MaybeArced::Unarced(Tree::PackedLeaf(PackedLeaf::single(value)))
             } else if let Some(MaybeArced::Unarced(Tree::PackedLeaf(mut leaf))) = self.stack.pop() {
                 leaf.push(value)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,6 @@ pub enum Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -20,9 +20,9 @@ pub trait ImmList<T: Value> {
         self.len().as_usize() == 0
     }
 
-    fn iter_from(&self, index: usize) -> Iter<T>;
+    fn iter_from(&self, index: usize) -> Iter<'_, T>;
 
-    fn level_iter_from(&self, index: usize) -> LevelIter<T>;
+    fn level_iter_from(&self, index: usize) -> LevelIter<'_, T>;
 }
 
 pub trait MutList<T: Value>: ImmList<T> {
@@ -70,7 +70,7 @@ where
             .get_mut_with(idx, |idx| self.backing.get(idx).cloned())
     }
 
-    pub fn get_cow(&mut self, index: usize) -> Option<Cow<T>> {
+    pub fn get_cow(&mut self, index: usize) -> Option<Cow<'_, T>> {
         self.updates
             .get_cow_with(index, |idx| self.backing.get(idx))
     }
@@ -96,11 +96,11 @@ where
         !self.updates.is_empty()
     }
 
-    pub fn iter(&self) -> InterfaceIter<T, U> {
+    pub fn iter(&self) -> InterfaceIter<'_, T, U> {
         self.iter_from(0)
     }
 
-    pub fn iter_from(&self, index: usize) -> InterfaceIter<T, U> {
+    pub fn iter_from(&self, index: usize) -> InterfaceIter<'_, T, U> {
         InterfaceIter {
             tree_iter: self.backing.iter_from(index),
             updates: &self.updates,
@@ -109,7 +109,7 @@ where
         }
     }
 
-    pub fn iter_cow(&mut self) -> InterfaceIterCow<T, U> {
+    pub fn iter_cow(&mut self) -> InterfaceIterCow<'_, T, U> {
         let index = 0;
         InterfaceIterCow {
             tree_iter: self.backing.iter_from(index),
@@ -118,7 +118,7 @@ where
         }
     }
 
-    pub fn level_iter_from(&self, index: usize) -> Result<LevelIter<T>, Error> {
+    pub fn level_iter_from(&self, index: usize) -> Result<LevelIter<'_, T>, Error> {
         if self.has_pending_updates() {
             Err(Error::LevelIterPendingUpdates)
         } else {

--- a/src/interface_iter.rs
+++ b/src/interface_iter.rs
@@ -39,7 +39,7 @@ pub struct InterfaceIterCow<'a, T: Value, U: UpdateMap<T>> {
 }
 
 impl<T: Value, U: UpdateMap<T>> InterfaceIterCow<'_, T, U> {
-    pub fn next_cow(&mut self) -> Option<(usize, Cow<T>)> {
+    pub fn next_cow(&mut self) -> Option<(usize, Cow<'_, T>)> {
         let index = self.index;
         self.index += 1;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -113,11 +113,11 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
         self.iter().cloned().collect()
     }
 
-    pub fn iter(&self) -> InterfaceIter<T, U> {
+    pub fn iter(&self) -> InterfaceIter<'_, T, U> {
         self.interface.iter()
     }
 
-    pub fn iter_from(&self, index: usize) -> Result<InterfaceIter<T, U>, Error> {
+    pub fn iter_from(&self, index: usize) -> Result<InterfaceIter<'_, T, U>, Error> {
         // Return an empty iterator at index == length, just like slicing.
         if index > self.len() {
             return Err(Error::OutOfBoundsIterFrom {
@@ -129,7 +129,7 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
     }
 
     /// Iterate all internal nodes on the same level as `index`.
-    pub fn level_iter_from(&self, index: usize) -> Result<LevelIter<T>, Error> {
+    pub fn level_iter_from(&self, index: usize) -> Result<LevelIter<'_, T>, Error> {
         // Return an empty iterator at index == length, just like slicing.
         if index > self.len() {
             return Err(Error::OutOfBoundsIterFrom {
@@ -140,20 +140,20 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
         self.interface.level_iter_from(index)
     }
 
-    pub fn iter_cow(&mut self) -> InterfaceIterCow<T, U> {
+    pub fn iter_cow(&mut self) -> InterfaceIterCow<'_, T, U> {
         self.interface.iter_cow()
     }
 
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
-    pub fn get(&self, index: usize) -> Option<&T> {
+    pub fn get(&self, index: usize) -> Option<&'_ T> {
         self.interface.get(index)
     }
 
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&'_ mut T> {
         self.interface.get_mut(index)
     }
 
-    pub fn get_cow(&mut self, index: usize) -> Option<Cow<T>> {
+    pub fn get_cow(&mut self, index: usize) -> Option<Cow<'_, T>> {
         self.interface.get_cow(index)
     }
 
@@ -252,11 +252,11 @@ impl<T: Value, N: Unsigned> ImmList<T> for ListInner<T, N> {
         self.length
     }
 
-    fn iter_from(&self, index: usize) -> Iter<T> {
+    fn iter_from(&self, index: usize) -> Iter<'_, T> {
         Iter::from_index(index, &self.tree, self.depth, self.length)
     }
 
-    fn level_iter_from(&self, index: usize) -> LevelIter<T> {
+    fn level_iter_from(&self, index: usize) -> LevelIter<'_, T> {
         LevelIter::from_index(index, &self.tree, self.depth, self.length)
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -496,8 +496,7 @@ where
 
             if num_items > max_len {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
-                    "List of {} items exceeds maximum of {}",
-                    num_items, max_len
+                    "List of {num_items} items exceeds maximum of {max_len}"
                 )));
             }
 
@@ -507,7 +506,7 @@ where
                     .map(T::from_ssz_bytes),
                 |iter| {
                     List::try_from_iter(iter).map_err(|e| {
-                        ssz::DecodeError::BytesInvalid(format!("Error building ssz List: {:?}", e))
+                        ssz::DecodeError::BytesInvalid(format!("Error building ssz List: {e:?}"))
                     })
                 },
             )?

--- a/src/repeat.rs
+++ b/src/repeat.rs
@@ -49,7 +49,7 @@ where
                     1,
                 )]
             }
-            [(repeat_leaf, repeat_count)] if repeat_count % 2 == 0 => {
+            [(repeat_leaf, repeat_count)] if repeat_count.is_multiple_of(2) => {
                 smallvec![(
                     Tree::node(repeat_leaf.clone(), repeat_leaf.clone(), Hash256::ZERO),
                     repeat_count / 2,
@@ -74,7 +74,7 @@ where
                 )]
             }
             [(repeat_leaf, repeat_count), (lonely_leaf, 1)] => {
-                if repeat_count % 2 == 0 {
+                if repeat_count.is_multiple_of(2) {
                     smallvec![
                         (
                             Tree::node(repeat_leaf.clone(), repeat_leaf.clone(), Hash256::ZERO),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -36,7 +36,7 @@ where
             std::iter::from_fn(|| seq.next_element().transpose()),
             |iter| {
                 List::try_from_iter(iter).map_err(|e| {
-                    serde::de::Error::custom(format!("Error deserializing List: {:?}", e))
+                    serde::de::Error::custom(format!("Error deserializing List: {e:?}"))
                 })
             },
         )?

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -371,11 +371,10 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> Decode for Vector<T, N, U> {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        let list = List::from_ssz_bytes(bytes).map_err(|e| {
-            ssz::DecodeError::BytesInvalid(format!("Error decoding vector: {:?}", e))
-        })?;
+        let list = List::from_ssz_bytes(bytes)
+            .map_err(|e| ssz::DecodeError::BytesInvalid(format!("Error decoding vector: {e:?}")))?;
         Self::try_from(list).map_err(|e| {
-            ssz::DecodeError::BytesInvalid(format!("Wrong number of vector elements: {:?}", e))
+            ssz::DecodeError::BytesInvalid(format!("Wrong number of vector elements: {e:?}"))
         })
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -65,11 +65,11 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
         self.iter().cloned().collect()
     }
 
-    pub fn iter(&self) -> InterfaceIter<T, U> {
+    pub fn iter(&self) -> InterfaceIter<'_, T, U> {
         self.interface.iter()
     }
 
-    pub fn iter_from(&self, index: usize) -> Result<InterfaceIter<T, U>, Error> {
+    pub fn iter_from(&self, index: usize) -> Result<InterfaceIter<'_, T, U>, Error> {
         if index > self.len() {
             return Err(Error::OutOfBoundsIterFrom {
                 index,
@@ -80,15 +80,15 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
     }
 
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
-    pub fn get(&self, index: usize) -> Option<&T> {
+    pub fn get(&self, index: usize) -> Option<&'_ T> {
         self.interface.get(index)
     }
 
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&'_ mut T> {
         self.interface.get_mut(index)
     }
 
-    pub fn get_cow(&mut self, index: usize) -> Option<Cow<T>> {
+    pub fn get_cow(&mut self, index: usize) -> Option<Cow<'_, T>> {
         self.interface.get_cow(index)
     }
 
@@ -208,11 +208,11 @@ impl<T: Value, N: Unsigned> ImmList<T> for VectorInner<T, N> {
         Length(N::to_usize())
     }
 
-    fn iter_from(&self, index: usize) -> Iter<T> {
+    fn iter_from(&self, index: usize) -> Iter<'_, T> {
         Iter::from_index(index, &self.tree, self.depth, Length(N::to_usize()))
     }
 
-    fn level_iter_from(&self, index: usize) -> LevelIter<T> {
+    fn level_iter_from(&self, index: usize) -> LevelIter<'_, T> {
         LevelIter::from_index(index, &self.tree, self.depth, Length(N::to_usize()))
     }
 }


### PR DESCRIPTION
Fix some Clippy lints, mostly just error formatting.