### PR TITLE
Bump tree_hash and ssz_types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.13.0"
 parking_lot = "0.12.1"
 rayon = "1.5.1"
 serde = { version = "1.0.0", features = ["derive"] }
-tree_hash = "0.11"
+tree_hash = "0.12"
 triomphe = "0.1.5"
 typenum = "1.14.0"
 vec_map = "0.8.2"
@@ -34,9 +34,9 @@ alloy-primitives = { version = "1.0.0" }
 context_deserialize = { version = "0.2", optional = true }
 
 [dev-dependencies]
-ssz_types = "0.13"
+ssz_types = "0.14"
 proptest = "1.0.0"
-tree_hash_derive = "0.11"
+tree_hash_derive = "0.12"
 criterion = "0.5"
 dhat = "0.3.3"
 serde_json = "1.0.0"


### PR DESCRIPTION
Need this for a new release so we can avoid duplicate versions of `ethereum_ssz`.