### PR TITLE
Disable DHAT tests under Tarpaulin

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -60,7 +60,7 @@ jobs:
       uses: taiki-e/install-action@cargo-tarpaulin
     - name: Check code coverage with cargo-tarpaulin
       # Using --lib to avoid DHAT issues
-      run: cargo-tarpaulin --workspace --all-features --out xml --lib
+      run: cargo-tarpaulin --workspace --all-features --out xml --lib --timeout 1200
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v4
       with:


### PR DESCRIPTION
The DHAT memory tests seem to be flaky under Tarpaulin, which kind of makes sense because running two tools to augment the code at the same time is a bit weird. This PR prevents those tests running under Tarpaulin.