### PR TITLE
Remove type construction from tree_hash benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ context_deserialize = { version = "0.2", optional = true }
 ssz_types = "0.14"
 proptest = "1.0.0"
 tree_hash_derive = "0.12"
-criterion = "0.5"
+criterion = "0.8"
 dhat = "0.3.3"
 serde_json = "1.0.0"
 

--- a/benches/tree_hash_root.rs
+++ b/benches/tree_hash_root.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use milhouse::{List, Vector};
 use ssz_types::VariableList;
 use tree_hash::TreeHash;
@@ -14,10 +14,11 @@ pub fn tree_hash_root(c: &mut Criterion) {
         BenchmarkId::new("tree_hash_root_list", size),
         &size,
         |b, &size| {
-            b.iter(|| {
-                let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
-                l1.tree_hash_root()
-            });
+            b.iter_batched(
+                || List::<u64, C>::try_from_iter(0..size).unwrap(),
+                |l1| l1.tree_hash_root(),
+                BatchSize::LargeInput,
+            );
         },
     );
 
@@ -25,10 +26,11 @@ pub fn tree_hash_root(c: &mut Criterion) {
         BenchmarkId::new("tree_hash_root_vector", size),
         &size,
         |b, &size| {
-            b.iter(|| {
-                let v1 = Vector::<u64, D>::try_from_iter(0..size).unwrap();
-                v1.tree_hash_root()
-            });
+            b.iter_batched(
+                || Vector::<u64, D>::try_from_iter(0..size).unwrap(),
+                |v1| v1.tree_hash_root(),
+                BatchSize::LargeInput,
+            );
         },
     );
 
@@ -37,10 +39,11 @@ pub fn tree_hash_root(c: &mut Criterion) {
         BenchmarkId::new("tree_hash_root_variable_list", size),
         &size,
         |b, &size| {
-            b.iter(|| {
-                let l1 = VariableList::<u64, C>::new((0..size).collect()).unwrap();
-                l1.tree_hash_root()
-            })
+            b.iter_batched(
+                || VariableList::<u64, C>::new((0..size).collect()).unwrap(),
+                |l1| l1.tree_hash_root(),
+                BatchSize::LargeInput,
+            );
         },
     );
 
@@ -48,22 +51,27 @@ pub fn tree_hash_root(c: &mut Criterion) {
         BenchmarkId::new("tree_hash_root_list_parallel", size),
         &size,
         |b, &size| {
-            b.iter(|| {
-                let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
-                let mut l2 = l1.clone();
-                l2.push(99).unwrap();
-                l2.apply_updates().unwrap();
+            b.iter_batched(
+                || {
+                    let l1 = List::<u64, C>::try_from_iter(0..size).unwrap();
+                    let mut l2 = l1.clone();
+                    l2.push(99).unwrap();
+                    l2.apply_updates().unwrap();
+                    (l1, l2)
+                },
+                |(l1, l2)| {
+                    let handle_1 = std::thread::spawn(move || {
+                        l1.tree_hash_root();
+                    });
+                    let handle_2 = std::thread::spawn(move || {
+                        l2.tree_hash_root();
+                    });
 
-                let handle_1 = std::thread::spawn(move || {
-                    l1.tree_hash_root();
-                });
-                let handle_2 = std::thread::spawn(move || {
-                    l2.tree_hash_root();
-                });
-
-                handle_1.join().unwrap();
-                handle_2.join().unwrap();
-            });
+                    handle_1.join().unwrap();
+                    handle_2.join().unwrap();
+                },
+                BatchSize::LargeInput,
+            );
         },
     );
 }


### PR DESCRIPTION
## Issue

While doing some optimization experiments I noticed that we actually measure the type construction and the hashing in the same benchmarks which dilutes the apparent effect of any hashing optimizations.

## Proposed Changes

Prevent the type construction from being timed by adding it into a "setup" closure which does not get benchmarked.
Doing it this way provides a "fresh" list every iteration so we avoid cache hits.

If we actually want to include benchmarks for construction we should make new benchmarks which specifically target that.

I also bumped `criterion` to 0.8