### PR TITLE
add cow_bytes: O(dirty_nodes) pairwise tree diff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,9 @@ harness = false
 name = "pop_front"
 harness = false
 
+[[bench]]
+name = "cow_bytes"
+harness = false
+
 [profile.bench]
 debug = true

--- a/benches/cow_bytes.rs
+++ b/benches/cow_bytes.rs
@@ -1,0 +1,93 @@
+//! Benchmark cow_bytes: pairwise tree walk for measuring COW cost.
+//!
+//! Tests at mainnet scale (1M, 2M entries) with varying numbers of dirty leaves.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use milhouse::List;
+use std::hint::black_box;
+
+type C = typenum::U1099511627776; // ValidatorRegistryLimit
+
+fn make_u64_pair(n: usize, dirty: usize) -> (List<u64, C>, List<u64, C>) {
+    let base = List::<u64, C>::try_from_iter(0..n as u64).unwrap();
+    let mut derived = base.clone();
+    let step = if dirty == 0 || dirty >= n {
+        1
+    } else {
+        n / dirty
+    };
+    let mut count = 0;
+    for i in (0..n).step_by(step) {
+        if count >= dirty {
+            break;
+        }
+        *derived.get_mut(i).unwrap() = u64::MAX;
+        count += 1;
+    }
+    derived.apply_updates().unwrap();
+    (base, derived)
+}
+
+fn bench_cow_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cow_bytes");
+    group.sample_size(10);
+
+    for (n, dirty, label) in [
+        (1_000_000, 0, "1M_0dirty"),
+        (1_000_000, 1, "1M_1dirty"),
+        (1_000_000, 128, "1M_128dirty"),
+        (1_000_000, 10_000, "1M_10kdirty"),
+        (1_000_000, 1_000_000, "1M_all_dirty"),
+        (2_000_000, 1, "2M_1dirty"),
+        (2_000_000, 128, "2M_128dirty"),
+        (2_000_000, 2_000_000, "2M_all_dirty"),
+    ] {
+        eprintln!("Building {label}...");
+        let (base, derived) = make_u64_pair(n, dirty);
+
+        group.bench_with_input(
+            BenchmarkId::new("list_u64", label),
+            &(&base, &derived),
+            |b, (base, derived)| {
+                b.iter(|| {
+                    black_box(derived.cow_bytes(base));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_cow_bytes_correctness(c: &mut Criterion) {
+    // Verify cow_bytes values are reasonable.
+    let mut group = c.benchmark_group("correctness_check");
+    group.sample_size(10);
+
+    // Identical: should be 0.
+    let (base, derived) = make_u64_pair(1000, 0);
+    let cow = derived.cow_bytes(&base);
+    assert_eq!(cow, 0, "identical lists should have 0 cow_bytes");
+
+    // 1 dirty: should be > 0.
+    let (base, derived) = make_u64_pair(1000, 1);
+    let cow = derived.cow_bytes(&base);
+    assert!(cow > 0, "1 dirty leaf should have non-zero cow_bytes");
+    eprintln!("1000 entries, 1 dirty: cow_bytes = {cow}");
+
+    // All dirty: should be large.
+    let (base, derived) = make_u64_pair(1000, 1000);
+    let cow = derived.cow_bytes(&base);
+    eprintln!("1000 entries, all dirty: cow_bytes = {cow}");
+
+    // Clone (no mutation): should be 0.
+    let base = List::<u64, C>::try_from_iter(0..1000u64).unwrap();
+    let clone = base.clone();
+    assert_eq!(clone.cow_bytes(&base), 0, "clone should be 0");
+
+    group.bench_function("noop", |b| b.iter(|| black_box(0)));
+    group.finish();
+}
+
+criterion_group!(benches, bench_cow_bytes, bench_cow_bytes_correctness);
+criterion_main!(benches);

--- a/benches/cow_bytes.rs
+++ b/benches/cow_bytes.rs
@@ -1,256 +1,236 @@
-//! Benchmarks for cow_bytes and total_unique_cow_tree_bytes.
+//! Benchmarks for total_unique_cow_tree_bytes simulating a realistic state cache.
 //!
-//! Simulates realistic state cache scenarios at mainnet scale:
-//! - Slot transitions: few random mutations (balances, roots, participation)
-//! - Epoch transitions: all balances + inactivity + participation rewritten
-//! - Effective balance updates: ~500 validator records mutated
+//! Each "state" has 4 fields matching the dominant BeaconState fields:
+//! - validators (FixedBytes<128> × 1M) — 267 MB, rarely dirty
+//! - balances (u64 × 1M) — 42 MB, fully dirty at epoch boundary
+//! - inactivity_scores (u64 × 1M) — 42 MB, fully dirty at epoch boundary
+//! - participation (u8 × 1M) — 5 MB, fully dirty at epoch boundary
 //!
-//! Each scenario is multiplied by expected cache size (128 states) to benchmark
-//! total_unique_cow_tree_bytes across the full cache.
+//! Scenarios simulate how the state cache looks in practice:
+//! (1) Slot transitions: ~10 balance changes, ~128 participation changes
+//! (2) Epoch transitions: all balances + inactivity + participation rewritten
+//! (3) Effective balance updates: ~500 validator mutations
 
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use milhouse::List;
+use alloy_primitives::FixedBytes;
+use criterion::{Criterion, criterion_group, criterion_main};
 use milhouse::mem::total_unique_cow_tree_bytes;
+use milhouse::{Arc, List, Tree};
 use std::hint::black_box;
 
-type C = typenum::U1099511627776; // ValidatorRegistryLimit
-const N: usize = 1_000_000; // mainnet validator count
+type C = typenum::U1099511627776;
+const N: usize = 1_000_000;
 
-/// Build a base list and derive states simulating slot transitions.
-/// Each state mutates ~10 random indices (proposer reward + a few attestation rewards).
-fn build_slot_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
-    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
-    let mut states = Vec::with_capacity(count);
-    for i in 0..count {
-        let mut s = base.clone();
-        // ~10 scattered balance changes per slot
-        for j in 0..10 {
-            let idx = (i * 137 + j * 7919) % N; // pseudo-random scatter
-            *s.get_mut(idx).unwrap() = u64::MAX;
-        }
-        s.apply_updates().unwrap();
-        states.push(s);
-    }
-    (base, states)
+/// A minimal multi-field "state" matching the dominant BeaconState fields.
+struct MiniState {
+    validators: List<FixedBytes<128>, C>,
+    balances: List<u64, C>,
+    inactivity: List<u64, C>,
+    participation: List<u8, C>,
 }
 
-/// Build states simulating epoch transitions.
-/// Each state has ALL entries rewritten (balances after rewards/penalties).
-fn build_epoch_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
-    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
-    let mut states = Vec::with_capacity(count);
-    for i in 0..count {
-        let mut s = base.clone();
-        for idx in 0..N {
-            *s.get_mut(idx).unwrap() = (idx as u64).wrapping_add(i as u64);
+impl MiniState {
+    fn new() -> Self {
+        MiniState {
+            validators: List::new(vec![FixedBytes::<128>::ZERO; N]).unwrap(),
+            balances: List::try_from_iter(0..N as u64).unwrap(),
+            inactivity: List::try_from_iter(vec![0u64; N]).unwrap(),
+            participation: List::try_from_iter(vec![0u8; N]).unwrap(),
         }
-        s.apply_updates().unwrap();
-        states.push(s);
     }
-    (base, states)
 }
 
-/// Build states simulating effective balance updates.
-/// ~500 validators have their effective balance changed per epoch.
-fn build_eff_balance_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
-    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
-    let mut states = Vec::with_capacity(count);
-    for i in 0..count {
-        let mut s = base.clone();
-        for j in 0..500 {
-            let idx = (i * 311 + j * 6271) % N;
-            *s.get_mut(idx).unwrap() = u64::MAX;
+impl Clone for MiniState {
+    fn clone(&self) -> Self {
+        MiniState {
+            validators: self.validators.clone(),
+            balances: self.balances.clone(),
+            inactivity: self.inactivity.clone(),
+            participation: self.participation.clone(),
         }
-        s.apply_updates().unwrap();
-        states.push(s);
     }
-    (base, states)
 }
 
-/// Build a chain of states: each cloned from the previous, with ~10 mutations.
-/// This is the realistic head-following pattern where states share COW nodes.
-fn build_chain_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
-    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
-    let mut states = Vec::with_capacity(count);
-    let mut prev = base.clone();
-    for i in 0..count {
-        let mut s = prev.clone();
-        for j in 0..10 {
-            let idx = (i * 137 + j * 7919) % N;
-            *s.get_mut(idx).unwrap() = u64::MAX;
-        }
-        s.apply_updates().unwrap();
-        states.push(s.clone());
-        prev = s;
-    }
-    (base, states)
+/// Compute total unique bytes across all fields of all states vs the base.
+fn measure_all_fields(base: &MiniState, states: &[MiniState]) -> usize {
+    let mut total = 0;
+
+    // Validators
+    let base_v = base.validators.tree_root();
+    let derived_v: Vec<_> = states.iter().map(|s| s.validators.tree_root()).collect();
+    total += total_unique_cow_tree_bytes(base_v, &derived_v);
+
+    // Balances
+    let base_b = base.balances.tree_root();
+    let derived_b: Vec<_> = states.iter().map(|s| s.balances.tree_root()).collect();
+    total += total_unique_cow_tree_bytes(base_b, &derived_b);
+
+    // Inactivity
+    let base_i = base.inactivity.tree_root();
+    let derived_i: Vec<_> = states.iter().map(|s| s.inactivity.tree_root()).collect();
+    total += total_unique_cow_tree_bytes(base_i, &derived_i);
+
+    // Participation
+    let base_p = base.participation.tree_root();
+    let derived_p: Vec<_> = states.iter().map(|s| s.participation.tree_root()).collect();
+    total += total_unique_cow_tree_bytes(base_p, &derived_p);
+
+    total
 }
 
-/// Mixed cache: 4 epoch boundary states + 124 slot transition states (chained).
-fn build_mixed_cache() -> (List<u64, C>, Vec<List<u64, C>>) {
-    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
-    let mut states = Vec::with_capacity(128);
-
-    // 4 epoch boundary states (all entries rewritten)
-    for i in 0..4 {
-        let mut s = base.clone();
-        for idx in 0..N {
-            *s.get_mut(idx).unwrap() = (idx as u64).wrapping_add(i as u64 + 1);
-        }
-        s.apply_updates().unwrap();
-        states.push(s);
+/// Slot transition: ~10 balance changes, ~128 participation changes.
+fn apply_slot(state: &mut MiniState, slot: usize) {
+    for j in 0..10 {
+        let idx = (slot * 137 + j * 7919) % N;
+        *state.balances.get_mut(idx).unwrap() = u64::MAX;
     }
-
-    // 124 slot transition states (chained, ~10 mutations each)
-    let mut prev = base.clone();
-    for i in 0..124 {
-        let mut s = prev.clone();
-        for j in 0..10 {
-            let idx = (i * 137 + j * 7919) % N;
-            *s.get_mut(idx).unwrap() = u64::MAX;
-        }
-        s.apply_updates().unwrap();
-        states.push(s.clone());
-        prev = s;
+    for j in 0..128 {
+        let idx = (slot * 251 + j * 31) % N;
+        *state.participation.get_mut(idx).unwrap() = 0xFF;
     }
-
-    (base, states)
+    state.balances.apply_updates().unwrap();
+    state.participation.apply_updates().unwrap();
 }
 
-fn bench_total_unique(c: &mut Criterion) {
-    let mut group = c.benchmark_group("total_unique_cow_tree_bytes");
+/// Epoch transition: all balances + inactivity rewritten, participation replaced.
+fn apply_epoch(_base: &MiniState, state: &mut MiniState, epoch: usize) {
+    for idx in 0..N {
+        *state.balances.get_mut(idx).unwrap() = (idx as u64).wrapping_add(epoch as u64);
+    }
+    for idx in 0..N {
+        *state.inactivity.get_mut(idx).unwrap() = epoch as u64;
+    }
+    // Participation: new list (epoch rotation)
+    state.participation = List::try_from_iter(vec![0u8; N]).unwrap();
+
+    state.balances.apply_updates().unwrap();
+    state.inactivity.apply_updates().unwrap();
+}
+
+/// Effective balance updates: ~500 validator mutations.
+fn apply_eff_balance(state: &mut MiniState, epoch: usize) {
+    for j in 0..500 {
+        let idx = (epoch * 311 + j * 6271) % N;
+        let mut val = FixedBytes::<128>::ZERO;
+        val.0[0] = epoch as u8;
+        *state.validators.get_mut(idx).unwrap() = val;
+    }
+    state.validators.apply_updates().unwrap();
+}
+
+fn bench_realistic_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("realistic_cache");
     group.sample_size(10);
 
-    // Scenario 1: Slot transitions (few mutations per state)
-    for cache_size in [32, 64, 128] {
-        eprintln!("Building {cache_size} slot states...");
-        let (base, states) = build_slot_states(cache_size);
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
-
-        group.bench_with_input(
-            BenchmarkId::new("slot_transitions", cache_size),
-            &(&base, &refs),
-            |b, (base, refs)| {
-                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
-            },
-        );
-    }
-
-    // Scenario 2: Epoch transitions (all entries dirty)
-    for cache_size in [4, 8, 16] {
-        eprintln!("Building {cache_size} epoch states...");
-        let (base, states) = build_epoch_states(cache_size);
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
-
-        group.bench_with_input(
-            BenchmarkId::new("epoch_transitions", cache_size),
-            &(&base, &refs),
-            |b, (base, refs)| {
-                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
-            },
-        );
-    }
-
-    // Scenario 3: Effective balance updates (~500 mutations per state)
-    for cache_size in [32, 64, 128] {
-        eprintln!("Building {cache_size} eff_balance states...");
-        let (base, states) = build_eff_balance_states(cache_size);
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
-
-        group.bench_with_input(
-            BenchmarkId::new("eff_balance_updates", cache_size),
-            &(&base, &refs),
-            |b, (base, refs)| {
-                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
-            },
-        );
-    }
-
-    // Scenario 4: Chain of slot transitions (states cloned from previous)
-    for cache_size in [32, 64, 128] {
-        eprintln!("Building {cache_size} chain states...");
-        let (base, states) = build_chain_states(cache_size);
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
-
-        group.bench_with_input(
-            BenchmarkId::new("chain_slots", cache_size),
-            &(&base, &refs),
-            |b, (base, refs)| {
-                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
-            },
-        );
-    }
-
-    // Scenario 5: Mixed realistic cache (4 epoch + 124 chained slots)
+    // Scenario 1: 128 slot-transition states (chained, like head-following)
     {
-        eprintln!("Building mixed cache (4 epoch + 124 chain)...");
-        let (base, states) = build_mixed_cache();
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+        eprintln!("Building 128 chained slot states (4 fields each)...");
+        let base = MiniState::new();
+        let mut states = Vec::with_capacity(128);
+        let mut prev = base.clone();
+        for i in 0..128 {
+            let mut s = prev.clone();
+            apply_slot(&mut s, i);
+            states.push(s.clone());
+            prev = s;
+        }
 
-        group.bench_function("mixed_cache_128", |b| {
-            b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), &refs)));
+        group.bench_function("128_slot_chain", |b| {
+            b.iter(|| black_box(measure_all_fields(&base, &states)));
         });
+
+        let bytes = measure_all_fields(&base, &states);
+        eprintln!("  128 slot chain: {} MB unique", bytes / (1024 * 1024));
     }
 
-    group.finish();
-}
+    // Scenario 2: 4 epoch boundary + 124 chained slot states
+    {
+        eprintln!("Building mixed cache (4 epoch + 124 slot chain)...");
+        let base = MiniState::new();
+        let mut states = Vec::with_capacity(128);
 
-fn bench_comparison(c: &mut Criterion) {
-    let mut group = c.benchmark_group("unique_vs_sum");
-    group.sample_size(10);
+        for i in 0..4 {
+            let mut s = base.clone();
+            apply_epoch(&base, &mut s, i + 1);
+            states.push(s);
+        }
 
-    // Compare total_unique_cow_tree_bytes vs naive sum of cow_bytes
-    // to show how much deduplication helps.
-    for (label, cache_size, builder) in [
-        ("slot_128", 128usize, build_slot_states as fn(usize) -> _),
-        ("eff_balance_128", 128, build_eff_balance_states),
-        ("epoch_8", 8, build_epoch_states),
-    ] {
-        eprintln!("Building comparison: {label}...");
-        let (base, states) = builder(cache_size);
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+        let mut prev = base.clone();
+        for i in 0..124 {
+            let mut s = prev.clone();
+            apply_slot(&mut s, i);
+            states.push(s.clone());
+            prev = s;
+        }
 
-        group.bench_with_input(
-            BenchmarkId::new("unique", label),
-            &(&base, &refs),
-            |b, (base, refs)| {
-                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
-            },
-        );
+        group.bench_function("mixed_4epoch_124slot", |b| {
+            b.iter(|| black_box(measure_all_fields(&base, &states)));
+        });
 
-        group.bench_with_input(
-            BenchmarkId::new("naive_sum", label),
-            &(&base, &states),
-            |b, (base, states)| {
-                b.iter(|| {
-                    let sum: usize = states.iter().map(|s| s.cow_bytes(base)).sum();
-                    black_box(sum);
-                });
-            },
-        );
+        let bytes = measure_all_fields(&base, &states);
+        eprintln!("  mixed cache: {} MB unique", bytes / (1024 * 1024));
     }
 
-    // Print dedup ratio for each scenario
-    for (label, cache_size, builder) in [
-        ("slot_128", 128usize, build_slot_states as fn(usize) -> _),
-        ("chain_128", 128, build_chain_states),
-        ("eff_balance_128", 128, build_eff_balance_states),
-        ("epoch_8", 8, build_epoch_states),
-    ] {
-        let (base, states) = builder(cache_size);
-        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
-        let unique = total_unique_cow_tree_bytes(base.tree_root(), &refs);
-        let naive: usize = states.iter().map(|s| s.cow_bytes(&base)).sum();
+    // Scenario 3: 4 epoch + 4 eff_balance + 120 slot chain
+    {
+        eprintln!("Building cache with eff_balance updates...");
+        let base = MiniState::new();
+        let mut states = Vec::with_capacity(128);
+
+        for i in 0..4 {
+            let mut s = base.clone();
+            apply_epoch(&base, &mut s, i + 1);
+            states.push(s);
+        }
+
+        for i in 0..4 {
+            let mut s = base.clone();
+            apply_eff_balance(&mut s, i + 1);
+            states.push(s);
+        }
+
+        let mut prev = base.clone();
+        for i in 0..120 {
+            let mut s = prev.clone();
+            apply_slot(&mut s, i);
+            states.push(s.clone());
+            prev = s;
+        }
+
+        group.bench_function("mixed_4epoch_4eff_120slot", |b| {
+            b.iter(|| black_box(measure_all_fields(&base, &states)));
+        });
+
+        let bytes = measure_all_fields(&base, &states);
         eprintln!(
-            "{label}: unique={} naive_sum={} ratio={:.2}x",
-            unique,
-            naive,
-            naive as f64 / unique as f64,
+            "  mixed+eff_balance cache: {} MB unique",
+            bytes / (1024 * 1024)
+        );
+    }
+
+    // Scenario 4: Just slot transitions (independent, not chained)
+    {
+        eprintln!("Building 128 independent slot states...");
+        let base = MiniState::new();
+        let mut states = Vec::with_capacity(128);
+        for i in 0..128 {
+            let mut s = base.clone();
+            apply_slot(&mut s, i);
+            states.push(s);
+        }
+
+        group.bench_function("128_slot_independent", |b| {
+            b.iter(|| black_box(measure_all_fields(&base, &states)));
+        });
+
+        let bytes = measure_all_fields(&base, &states);
+        eprintln!(
+            "  128 slot independent: {} MB unique",
+            bytes / (1024 * 1024)
         );
     }
 
     group.finish();
 }
 
-criterion_group!(benches, bench_total_unique, bench_comparison);
+criterion_group!(benches, bench_realistic_cache);
 criterion_main!(benches);

--- a/benches/cow_bytes.rs
+++ b/benches/cow_bytes.rs
@@ -1,93 +1,256 @@
-//! Benchmark cow_bytes: pairwise tree walk for measuring COW cost.
+//! Benchmarks for cow_bytes and total_unique_cow_tree_bytes.
 //!
-//! Tests at mainnet scale (1M, 2M entries) with varying numbers of dirty leaves.
+//! Simulates realistic state cache scenarios at mainnet scale:
+//! - Slot transitions: few random mutations (balances, roots, participation)
+//! - Epoch transitions: all balances + inactivity + participation rewritten
+//! - Effective balance updates: ~500 validator records mutated
+//!
+//! Each scenario is multiplied by expected cache size (128 states) to benchmark
+//! total_unique_cow_tree_bytes across the full cache.
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use milhouse::List;
+use milhouse::mem::total_unique_cow_tree_bytes;
 use std::hint::black_box;
 
 type C = typenum::U1099511627776; // ValidatorRegistryLimit
+const N: usize = 1_000_000; // mainnet validator count
 
-fn make_u64_pair(n: usize, dirty: usize) -> (List<u64, C>, List<u64, C>) {
-    let base = List::<u64, C>::try_from_iter(0..n as u64).unwrap();
-    let mut derived = base.clone();
-    let step = if dirty == 0 || dirty >= n {
-        1
-    } else {
-        n / dirty
-    };
-    let mut count = 0;
-    for i in (0..n).step_by(step) {
-        if count >= dirty {
-            break;
+/// Build a base list and derive states simulating slot transitions.
+/// Each state mutates ~10 random indices (proposer reward + a few attestation rewards).
+fn build_slot_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
+    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
+    let mut states = Vec::with_capacity(count);
+    for i in 0..count {
+        let mut s = base.clone();
+        // ~10 scattered balance changes per slot
+        for j in 0..10 {
+            let idx = (i * 137 + j * 7919) % N; // pseudo-random scatter
+            *s.get_mut(idx).unwrap() = u64::MAX;
         }
-        *derived.get_mut(i).unwrap() = u64::MAX;
-        count += 1;
+        s.apply_updates().unwrap();
+        states.push(s);
     }
-    derived.apply_updates().unwrap();
-    (base, derived)
+    (base, states)
 }
 
-fn bench_cow_bytes(c: &mut Criterion) {
-    let mut group = c.benchmark_group("cow_bytes");
+/// Build states simulating epoch transitions.
+/// Each state has ALL entries rewritten (balances after rewards/penalties).
+fn build_epoch_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
+    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
+    let mut states = Vec::with_capacity(count);
+    for i in 0..count {
+        let mut s = base.clone();
+        for idx in 0..N {
+            *s.get_mut(idx).unwrap() = (idx as u64).wrapping_add(i as u64);
+        }
+        s.apply_updates().unwrap();
+        states.push(s);
+    }
+    (base, states)
+}
+
+/// Build states simulating effective balance updates.
+/// ~500 validators have their effective balance changed per epoch.
+fn build_eff_balance_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
+    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
+    let mut states = Vec::with_capacity(count);
+    for i in 0..count {
+        let mut s = base.clone();
+        for j in 0..500 {
+            let idx = (i * 311 + j * 6271) % N;
+            *s.get_mut(idx).unwrap() = u64::MAX;
+        }
+        s.apply_updates().unwrap();
+        states.push(s);
+    }
+    (base, states)
+}
+
+/// Build a chain of states: each cloned from the previous, with ~10 mutations.
+/// This is the realistic head-following pattern where states share COW nodes.
+fn build_chain_states(count: usize) -> (List<u64, C>, Vec<List<u64, C>>) {
+    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
+    let mut states = Vec::with_capacity(count);
+    let mut prev = base.clone();
+    for i in 0..count {
+        let mut s = prev.clone();
+        for j in 0..10 {
+            let idx = (i * 137 + j * 7919) % N;
+            *s.get_mut(idx).unwrap() = u64::MAX;
+        }
+        s.apply_updates().unwrap();
+        states.push(s.clone());
+        prev = s;
+    }
+    (base, states)
+}
+
+/// Mixed cache: 4 epoch boundary states + 124 slot transition states (chained).
+fn build_mixed_cache() -> (List<u64, C>, Vec<List<u64, C>>) {
+    let base = List::<u64, C>::try_from_iter(0..N as u64).unwrap();
+    let mut states = Vec::with_capacity(128);
+
+    // 4 epoch boundary states (all entries rewritten)
+    for i in 0..4 {
+        let mut s = base.clone();
+        for idx in 0..N {
+            *s.get_mut(idx).unwrap() = (idx as u64).wrapping_add(i as u64 + 1);
+        }
+        s.apply_updates().unwrap();
+        states.push(s);
+    }
+
+    // 124 slot transition states (chained, ~10 mutations each)
+    let mut prev = base.clone();
+    for i in 0..124 {
+        let mut s = prev.clone();
+        for j in 0..10 {
+            let idx = (i * 137 + j * 7919) % N;
+            *s.get_mut(idx).unwrap() = u64::MAX;
+        }
+        s.apply_updates().unwrap();
+        states.push(s.clone());
+        prev = s;
+    }
+
+    (base, states)
+}
+
+fn bench_total_unique(c: &mut Criterion) {
+    let mut group = c.benchmark_group("total_unique_cow_tree_bytes");
     group.sample_size(10);
 
-    for (n, dirty, label) in [
-        (1_000_000, 0, "1M_0dirty"),
-        (1_000_000, 1, "1M_1dirty"),
-        (1_000_000, 128, "1M_128dirty"),
-        (1_000_000, 10_000, "1M_10kdirty"),
-        (1_000_000, 1_000_000, "1M_all_dirty"),
-        (2_000_000, 1, "2M_1dirty"),
-        (2_000_000, 128, "2M_128dirty"),
-        (2_000_000, 2_000_000, "2M_all_dirty"),
-    ] {
-        eprintln!("Building {label}...");
-        let (base, derived) = make_u64_pair(n, dirty);
+    // Scenario 1: Slot transitions (few mutations per state)
+    for cache_size in [32, 64, 128] {
+        eprintln!("Building {cache_size} slot states...");
+        let (base, states) = build_slot_states(cache_size);
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
 
         group.bench_with_input(
-            BenchmarkId::new("list_u64", label),
-            &(&base, &derived),
-            |b, (base, derived)| {
+            BenchmarkId::new("slot_transitions", cache_size),
+            &(&base, &refs),
+            |b, (base, refs)| {
+                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
+            },
+        );
+    }
+
+    // Scenario 2: Epoch transitions (all entries dirty)
+    for cache_size in [4, 8, 16] {
+        eprintln!("Building {cache_size} epoch states...");
+        let (base, states) = build_epoch_states(cache_size);
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("epoch_transitions", cache_size),
+            &(&base, &refs),
+            |b, (base, refs)| {
+                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
+            },
+        );
+    }
+
+    // Scenario 3: Effective balance updates (~500 mutations per state)
+    for cache_size in [32, 64, 128] {
+        eprintln!("Building {cache_size} eff_balance states...");
+        let (base, states) = build_eff_balance_states(cache_size);
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("eff_balance_updates", cache_size),
+            &(&base, &refs),
+            |b, (base, refs)| {
+                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
+            },
+        );
+    }
+
+    // Scenario 4: Chain of slot transitions (states cloned from previous)
+    for cache_size in [32, 64, 128] {
+        eprintln!("Building {cache_size} chain states...");
+        let (base, states) = build_chain_states(cache_size);
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("chain_slots", cache_size),
+            &(&base, &refs),
+            |b, (base, refs)| {
+                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
+            },
+        );
+    }
+
+    // Scenario 5: Mixed realistic cache (4 epoch + 124 chained slots)
+    {
+        eprintln!("Building mixed cache (4 epoch + 124 chain)...");
+        let (base, states) = build_mixed_cache();
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+
+        group.bench_function("mixed_cache_128", |b| {
+            b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), &refs)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unique_vs_sum");
+    group.sample_size(10);
+
+    // Compare total_unique_cow_tree_bytes vs naive sum of cow_bytes
+    // to show how much deduplication helps.
+    for (label, cache_size, builder) in [
+        ("slot_128", 128usize, build_slot_states as fn(usize) -> _),
+        ("eff_balance_128", 128, build_eff_balance_states),
+        ("epoch_8", 8, build_epoch_states),
+    ] {
+        eprintln!("Building comparison: {label}...");
+        let (base, states) = builder(cache_size);
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("unique", label),
+            &(&base, &refs),
+            |b, (base, refs)| {
+                b.iter(|| black_box(total_unique_cow_tree_bytes(base.tree_root(), refs)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("naive_sum", label),
+            &(&base, &states),
+            |b, (base, states)| {
                 b.iter(|| {
-                    black_box(derived.cow_bytes(base));
+                    let sum: usize = states.iter().map(|s| s.cow_bytes(base)).sum();
+                    black_box(sum);
                 });
             },
+        );
+    }
+
+    // Print dedup ratio for each scenario
+    for (label, cache_size, builder) in [
+        ("slot_128", 128usize, build_slot_states as fn(usize) -> _),
+        ("chain_128", 128, build_chain_states),
+        ("eff_balance_128", 128, build_eff_balance_states),
+        ("epoch_8", 8, build_epoch_states),
+    ] {
+        let (base, states) = builder(cache_size);
+        let refs: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+        let unique = total_unique_cow_tree_bytes(base.tree_root(), &refs);
+        let naive: usize = states.iter().map(|s| s.cow_bytes(&base)).sum();
+        eprintln!(
+            "{label}: unique={} naive_sum={} ratio={:.2}x",
+            unique,
+            naive,
+            naive as f64 / unique as f64,
         );
     }
 
     group.finish();
 }
 
-fn bench_cow_bytes_correctness(c: &mut Criterion) {
-    // Verify cow_bytes values are reasonable.
-    let mut group = c.benchmark_group("correctness_check");
-    group.sample_size(10);
-
-    // Identical: should be 0.
-    let (base, derived) = make_u64_pair(1000, 0);
-    let cow = derived.cow_bytes(&base);
-    assert_eq!(cow, 0, "identical lists should have 0 cow_bytes");
-
-    // 1 dirty: should be > 0.
-    let (base, derived) = make_u64_pair(1000, 1);
-    let cow = derived.cow_bytes(&base);
-    assert!(cow > 0, "1 dirty leaf should have non-zero cow_bytes");
-    eprintln!("1000 entries, 1 dirty: cow_bytes = {cow}");
-
-    // All dirty: should be large.
-    let (base, derived) = make_u64_pair(1000, 1000);
-    let cow = derived.cow_bytes(&base);
-    eprintln!("1000 entries, all dirty: cow_bytes = {cow}");
-
-    // Clone (no mutation): should be 0.
-    let base = List::<u64, C>::try_from_iter(0..1000u64).unwrap();
-    let clone = base.clone();
-    assert_eq!(clone.cow_bytes(&base), 0, "clone should be 0");
-
-    group.bench_function("noop", |b| b.iter(|| black_box(0)));
-    group.finish();
-}
-
-criterion_group!(benches, bench_cow_bytes, bench_cow_bytes_correctness);
+criterion_group!(benches, bench_total_unique, bench_comparison);
 criterion_main!(benches);

--- a/src/list.rs
+++ b/src/list.rs
@@ -162,6 +162,18 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
         Ok(self.interface.iter_cow_from(index))
     }
 
+    /// Compute the bytes owned by `self` that are not shared with `base`.
+    ///
+    /// O(dirty_nodes) — shared subtrees are skipped via `Arc::ptr_eq`.
+    pub fn cow_bytes(&self, base: &Self) -> usize {
+        crate::mem::cow_tree_bytes(&base.interface.backing.tree, &self.interface.backing.tree)
+    }
+
+    /// Total bytes of all tree nodes (no sharing baseline).
+    pub fn total_tree_bytes(&self) -> usize {
+        crate::mem::total_tree_bytes(&self.interface.backing.tree)
+    }
+
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
     pub fn get(&self, index: usize) -> Option<&'_ T> {
         self.interface.get(index)

--- a/src/list.rs
+++ b/src/list.rs
@@ -174,6 +174,11 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
         crate::mem::total_tree_bytes(&self.interface.backing.tree)
     }
 
+    /// Access the internal tree root for use with `total_unique_cow_tree_bytes`.
+    pub fn tree_root(&self) -> &Arc<Tree<T>> {
+        &self.interface.backing.tree
+    }
+
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
     pub fn get(&self, index: usize) -> Option<&'_ T> {
         self.interface.get(index)

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -158,6 +158,67 @@ impl<T: Value + MemorySize, N: Unsigned, U: UpdateMap<T>> MemorySize for Vector<
     }
 }
 
+/// Compute the bytes owned by `derived` that are not shared with `base`.
+///
+/// Walks both trees in parallel, comparing `Arc` pointers at each level. When pointers
+/// match, the entire subtree is shared and costs 0 — the recursion stops immediately.
+/// When pointers differ, the derived node is counted and its children are recursed.
+///
+/// Complexity: O(dirty_nodes), where dirty_nodes are the tree nodes that differ between
+/// the two trees. For a single leaf mutation in a tree of depth D, this visits ~D nodes.
+/// For a fully-rewritten tree, it visits all nodes (same as `total_tree_bytes`).
+///
+/// No allocations, no external state (unlike `MemoryTracker` which builds a `HashMap`).
+pub fn cow_tree_bytes<T: Value>(base: &Arc<Tree<T>>, derived: &Arc<Tree<T>>) -> usize {
+    if Arc::ptr_eq(base, derived) {
+        return 0;
+    }
+
+    let self_bytes = node_bytes::<T>(derived);
+
+    match (base.as_ref(), derived.as_ref()) {
+        (
+            Tree::Node {
+                left: bl,
+                right: br,
+                ..
+            },
+            Tree::Node {
+                left: dl,
+                right: dr,
+                ..
+            },
+        ) => self_bytes + cow_tree_bytes(bl, dl) + cow_tree_bytes(br, dr),
+        // Structure mismatch or derived is a leaf/zero — count the full derived subtree.
+        _ => self_bytes + children_bytes::<T>(derived),
+    }
+}
+
+/// Total bytes of all nodes in a tree. No sharing baseline.
+pub fn total_tree_bytes<T: Value>(tree: &Arc<Tree<T>>) -> usize {
+    node_bytes::<T>(tree) + children_bytes::<T>(tree)
+}
+
+/// Bytes consumed by a single tree node (not including its children).
+fn node_bytes<T: Value>(tree: &Arc<Tree<T>>) -> usize {
+    // Every node is an Arc<Tree<T>>: the Arc pointer + the Tree enum.
+    let overhead = std::mem::size_of::<Arc<Tree<T>>>() + std::mem::size_of::<Tree<T>>();
+    let leaf_data = match tree.as_ref() {
+        Tree::PackedLeaf(packed) => packed.values.capacity() * std::mem::size_of::<T>(),
+        Tree::Leaf(_) => std::mem::size_of::<Arc<T>>() + std::mem::size_of::<T>(),
+        Tree::Node { .. } | Tree::Zero(_) => 0,
+    };
+    overhead + leaf_data
+}
+
+/// Sum of `total_tree_bytes` for a node's children.
+fn children_bytes<T: Value>(tree: &Arc<Tree<T>>) -> usize {
+    match tree.as_ref() {
+        Tree::Node { left, right, .. } => total_tree_bytes(left) + total_tree_bytes(right),
+        _ => 0,
+    }
+}
+
 impl<const N: usize> MemorySize for FixedBytes<N> {
     fn self_pointer(&self) -> usize {
         self as *const _ as usize

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,6 +1,6 @@
 use crate::{Arc, List, Tree, UpdateMap, Value, Vector};
 use alloy_primitives::FixedBytes;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use typenum::Unsigned;
 
 /// Trait for types supporting memory usage tracking in a `MemoryTracker`.
@@ -215,6 +215,77 @@ fn node_bytes<T: Value>(tree: &Arc<Tree<T>>) -> usize {
 fn children_bytes<T: Value>(tree: &Arc<Tree<T>>) -> usize {
     match tree.as_ref() {
         Tree::Node { left, right, .. } => total_tree_bytes(left) + total_tree_bytes(right),
+        _ => 0,
+    }
+}
+
+/// Compute the total unique COW bytes across multiple derived trees relative to a shared base.
+///
+/// Like `cow_tree_bytes` but deduplicates across all derived trees using a `HashSet` of
+/// pointers. Nodes shared with `base` are skipped via `Arc::ptr_eq` (no base walk needed).
+/// Nodes shared between derived trees are counted once.
+///
+/// Complexity: O(total_unique_dirty_nodes) — each unique COW'd node is visited exactly once
+/// across all derived trees. The `HashSet` only contains dirty nodes (not base nodes), so it
+/// stays small.
+pub fn total_unique_cow_tree_bytes<T: Value>(
+    base: &Arc<Tree<T>>,
+    derived: &[&Arc<Tree<T>>],
+) -> usize {
+    let mut seen = HashSet::new();
+    let mut total = 0;
+    for d in derived {
+        total += cow_tree_bytes_dedup(base, d, &mut seen);
+    }
+    total
+}
+
+fn cow_tree_bytes_dedup<T: Value>(
+    base: &Arc<Tree<T>>,
+    derived: &Arc<Tree<T>>,
+    seen: &mut HashSet<usize>,
+) -> usize {
+    // Shared with base — entire subtree is free.
+    if Arc::ptr_eq(base, derived) {
+        return 0;
+    }
+
+    // Already counted from another derived tree — skip.
+    if !seen.insert(Arc::as_ptr(derived) as usize) {
+        return 0;
+    }
+
+    let self_bytes = node_bytes::<T>(derived);
+
+    match (base.as_ref(), derived.as_ref()) {
+        (
+            Tree::Node {
+                left: bl,
+                right: br,
+                ..
+            },
+            Tree::Node {
+                left: dl,
+                right: dr,
+                ..
+            },
+        ) => self_bytes + cow_tree_bytes_dedup(bl, dl, seen) + cow_tree_bytes_dedup(br, dr, seen),
+        _ => self_bytes + children_bytes_dedup::<T>(derived, seen),
+    }
+}
+
+fn children_bytes_dedup<T: Value>(tree: &Arc<Tree<T>>, seen: &mut HashSet<usize>) -> usize {
+    match tree.as_ref() {
+        Tree::Node { left, right, .. } => {
+            let mut total = 0;
+            if seen.insert(Arc::as_ptr(left) as usize) {
+                total += node_bytes::<T>(left) + children_bytes_dedup::<T>(left, seen);
+            }
+            if seen.insert(Arc::as_ptr(right) as usize) {
+                total += node_bytes::<T>(right) + children_bytes_dedup::<T>(right, seen);
+            }
+            total
+        }
         _ => 0,
     }
 }

--- a/src/tests/mem.rs
+++ b/src/tests/mem.rs
@@ -155,9 +155,9 @@ fn cow_bytes_includes_leaf_data() {
     // cow_bytes must account for the leaf data, not just tree node overhead.
     type Big = FixedBytes<10000>;
 
-    let base = List::<Big, typenum::U2>::new(vec![Box::new(Big::ZERO).as_ref().clone()]).unwrap();
+    let base = List::<Big, typenum::U2>::new(vec![Big::ZERO]).unwrap();
     let mut derived = base.clone();
-    *derived.get_mut(0).unwrap() = Box::new(FixedBytes([0xAA; 10000])).as_ref().clone();
+    *derived.get_mut(0).unwrap() = FixedBytes([0xAA; 10000]);
     derived.apply_updates().unwrap();
 
     let cow = derived.cow_bytes(&base);

--- a/src/tests/mem.rs
+++ b/src/tests/mem.rs
@@ -278,3 +278,46 @@ fn unique_cow_clone_only() {
     let unique = crate::mem::total_unique_cow_tree_bytes(base_tree, &[clone.tree_root()]);
     assert_eq!(unique, 0);
 }
+
+#[test]
+fn measure_mainnet_field_sizes() {
+    use alloy_primitives::FixedBytes;
+
+    let n = 1_000_000;
+    type C = typenum::U1099511627776;
+    type SPHR = typenum::U8192;
+    type EPHV = typenum::U65536;
+    type EPSV = typenum::U8192;
+
+    let balances = List::<u64, C>::try_from_iter(0..n as u64).unwrap();
+    let participation = List::<u8, C>::try_from_iter(vec![0u8; n]).unwrap();
+    let validators = List::<FixedBytes<128>, C>::new(vec![FixedBytes::<128>::ZERO; n]).unwrap();
+    let state_roots = crate::Vector::<FixedBytes<32>, SPHR>::default();
+    let randao = crate::Vector::<FixedBytes<32>, EPHV>::default();
+    let slashings = crate::Vector::<u64, EPSV>::default();
+
+    let mut total = 0;
+    for (name, bytes) in [
+        ("validators (128B×1M)", validators.total_tree_bytes()),
+        ("balances (u64×1M)", balances.total_tree_bytes()),
+        ("inactivity (u64×1M)", balances.total_tree_bytes()),
+        ("prev_part (u8×1M)", participation.total_tree_bytes()),
+        ("curr_part (u8×1M)", participation.total_tree_bytes()),
+        ("state_roots (H256×8192)", state_roots.total_tree_bytes()),
+        ("block_roots (H256×8192)", state_roots.total_tree_bytes()),
+        ("randao_mixes (H256×65536)", randao.total_tree_bytes()),
+        ("slashings (u64×8192)", slashings.total_tree_bytes()),
+    ] {
+        total += bytes;
+        eprintln!(
+            "  {name:<30} {bytes:>12} bytes {:>8.1} MB",
+            bytes as f64 / 1048576.0
+        );
+    }
+    eprintln!(
+        "  {:<30} {:>12} bytes {:>8.1} MB",
+        "TOTAL",
+        total,
+        total as f64 / 1048576.0
+    );
+}

--- a/src/tests/mem.rs
+++ b/src/tests/mem.rs
@@ -1,5 +1,5 @@
-use crate::{Vector, mem::MemoryTracker};
-use typenum::U1024;
+use crate::{List, Vector, mem::MemoryTracker};
+use typenum::{U1024, U1048576};
 
 #[test]
 fn vector_mutate_last() {
@@ -20,4 +20,129 @@ fn vector_mutate_last() {
 
     // The differential size of the second list should be less than 2% of the total size.
     assert!(50 * v2_stats.differential_size < v2_stats.total_size);
+}
+
+// ── cow_bytes tests ───────────────────────────────────────────────────
+
+#[test]
+fn cow_bytes_identical_is_zero() {
+    let list = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let clone = list.clone();
+    assert_eq!(clone.cow_bytes(&list), 0);
+}
+
+#[test]
+fn cow_bytes_single_mutation() {
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let mut derived = base.clone();
+    *derived.get_mut(0).unwrap() = u64::MAX;
+    derived.apply_updates().unwrap();
+
+    let cow = derived.cow_bytes(&base);
+    assert!(cow > 0, "single mutation should have non-zero cow_bytes");
+    // Should be much less than total (only one root-to-leaf path).
+    let total = base.total_tree_bytes();
+    assert!(
+        cow < total / 10,
+        "cow ({cow}) should be << total ({total}) for 1 mutation"
+    );
+}
+
+#[test]
+fn cow_bytes_all_dirty() {
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let mut derived = base.clone();
+    for i in 0..1000 {
+        *derived.get_mut(i).unwrap() = u64::MAX;
+    }
+    derived.apply_updates().unwrap();
+
+    let cow = derived.cow_bytes(&base);
+    let total = derived.total_tree_bytes();
+    // All dirty: cow should be close to total (minus shared Zero subtrees).
+    assert!(
+        cow > total / 2,
+        "all dirty: cow ({cow}) should be > half of total ({total})"
+    );
+}
+
+#[test]
+fn cow_bytes_matches_tracker_differential() {
+    // cow_bytes and MemoryTracker differential_size should agree on the tree portion.
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let mut derived = base.clone();
+    for i in (0..1000).step_by(10) {
+        *derived.get_mut(i).unwrap() = u64::MAX;
+    }
+    derived.apply_updates().unwrap();
+
+    let cow = derived.cow_bytes(&base);
+
+    let mut tracker = MemoryTracker::default();
+    tracker.track_item(&base);
+    let tracker_diff = tracker.track_item(&derived).differential_size;
+
+    // tracker_diff includes the List struct overhead; cow_bytes only counts tree nodes.
+    // cow_bytes should be close to tracker_diff (within the List struct size).
+    let list_overhead = std::mem::size_of::<List<u64, U1048576>>();
+    assert!(
+        cow <= tracker_diff,
+        "cow ({cow}) should be <= tracker_diff ({tracker_diff})"
+    );
+    assert!(
+        tracker_diff - cow <= list_overhead,
+        "difference ({}) should be <= list overhead ({list_overhead})",
+        tracker_diff - cow
+    );
+}
+
+#[test]
+fn cow_bytes_vector() {
+    let base = Vector::<u64, U1024>::new(vec![0u64; 1024]).unwrap();
+    let mut derived = base.clone();
+    *derived.get_mut(0).unwrap() = 1;
+    derived.apply_updates().unwrap();
+
+    let cow = derived.cow_bytes(&base);
+    assert!(cow > 0);
+
+    // Clone should be zero.
+    let clone = base.clone();
+    assert_eq!(clone.cow_bytes(&base), 0);
+}
+
+#[test]
+fn total_tree_bytes_nonzero() {
+    let list = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let total = list.total_tree_bytes();
+    // 1000 u64 values, packed 4 per leaf = 250 leaves. Each node is ~72 bytes.
+    // Total should be in the tens of KB range.
+    assert!(
+        total > 10_000,
+        "total ({total}) should be > 10KB for 1000 u64 entries"
+    );
+}
+
+#[test]
+fn cow_bytes_chain() {
+    // A → B → C chain: C.cow_bytes(A) >= C.cow_bytes(B)
+    let a = List::<u64, U1048576>::try_from_iter(0..500u64).unwrap();
+    let mut b = a.clone();
+    for i in 0..250 {
+        *b.get_mut(i).unwrap() = u64::MAX;
+    }
+    b.apply_updates().unwrap();
+
+    let mut c = b.clone();
+    for i in 250..500 {
+        *c.get_mut(i).unwrap() = u64::MAX;
+    }
+    c.apply_updates().unwrap();
+
+    let c_vs_a = c.cow_bytes(&a);
+    let c_vs_b = c.cow_bytes(&b);
+    let b_vs_a = b.cow_bytes(&a);
+
+    assert!(c_vs_a >= c_vs_b, "C vs A ({c_vs_a}) >= C vs B ({c_vs_b})");
+    assert!(c_vs_a >= b_vs_a, "C vs A ({c_vs_a}) >= B vs A ({b_vs_a})");
 }

--- a/src/tests/mem.rs
+++ b/src/tests/mem.rs
@@ -146,3 +146,29 @@ fn cow_bytes_chain() {
     assert!(c_vs_a >= c_vs_b, "C vs A ({c_vs_a}) >= C vs B ({c_vs_b})");
     assert!(c_vs_a >= b_vs_a, "C vs A ({c_vs_a}) >= B vs A ({b_vs_a})");
 }
+
+#[test]
+fn cow_bytes_includes_leaf_data() {
+    use alloy_primitives::FixedBytes;
+
+    // 10KB per entry, capacity 2. Uses Leaf<T> (unpacked, since size > 32 bytes).
+    // cow_bytes must account for the leaf data, not just tree node overhead.
+    type Big = FixedBytes<10000>;
+
+    let base = List::<Big, typenum::U2>::new(vec![Box::new(Big::ZERO).as_ref().clone()]).unwrap();
+    let mut derived = base.clone();
+    *derived.get_mut(0).unwrap() = Box::new(FixedBytes([0xAA; 10000])).as_ref().clone();
+    derived.apply_updates().unwrap();
+
+    let cow = derived.cow_bytes(&base);
+    assert!(
+        cow >= 10000,
+        "cow_bytes ({cow}) must be >= 10000 — leaf data must be counted"
+    );
+
+    let total = base.total_tree_bytes();
+    assert!(
+        total >= 10000,
+        "total_tree_bytes ({total}) must be >= 10000"
+    );
+}

--- a/src/tests/mem.rs
+++ b/src/tests/mem.rs
@@ -172,3 +172,109 @@ fn cow_bytes_includes_leaf_data() {
         "total_tree_bytes ({total}) must be >= 10000"
     );
 }
+
+// ── total_unique_cow_tree_bytes tests ─────────────────────────────────
+
+#[test]
+fn unique_cow_dedup_shared_states() {
+    // Two states cloned from the same base, both mutating the same index.
+    // Their COW'd paths overlap — unique count should be less than sum of individual.
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let mut s1 = base.clone();
+    *s1.get_mut(0).unwrap() = 111;
+    s1.apply_updates().unwrap();
+
+    let mut s2 = base.clone();
+    *s2.get_mut(0).unwrap() = 222;
+    s2.apply_updates().unwrap();
+
+    let base_tree = base.tree_root();
+    let individual_sum = s1.cow_bytes(&base) + s2.cow_bytes(&base);
+    let unique =
+        crate::mem::total_unique_cow_tree_bytes(base_tree, &[s1.tree_root(), s2.tree_root()]);
+
+    // Both mutated the same index but different values → different leaf nodes
+    // but shared internal path nodes. Unique should be less than sum.
+    assert!(unique > 0);
+    assert!(
+        unique <= individual_sum,
+        "unique ({unique}) should be <= sum of individual ({individual_sum})"
+    );
+}
+
+#[test]
+fn unique_cow_chain() {
+    // Chain: base → A → B. B shares A's COW'd nodes.
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let mut a = base.clone();
+    for i in 0..500 {
+        *a.get_mut(i).unwrap() = u64::MAX;
+    }
+    a.apply_updates().unwrap();
+
+    let mut b = a.clone();
+    for i in 500..1000 {
+        *b.get_mut(i).unwrap() = u64::MAX;
+    }
+    b.apply_updates().unwrap();
+
+    let base_tree = base.tree_root();
+    let unique =
+        crate::mem::total_unique_cow_tree_bytes(base_tree, &[a.tree_root(), b.tree_root()]);
+    let b_alone = b.cow_bytes(&base);
+
+    // B was cloned from A then modified further. B shares A's nodes for indices 0..500
+    // but has new nodes for 500..1000. A has its own path nodes for 0..500.
+    // Unique should be close to B's cost — A adds only the few path nodes that B replaced.
+    let individual_sum = a.cow_bytes(&base) + b.cow_bytes(&base);
+    assert!(
+        unique < individual_sum,
+        "unique ({unique}) should be < sum ({individual_sum}) due to sharing"
+    );
+    assert!(
+        unique >= b_alone,
+        "unique ({unique}) should be >= B alone ({b_alone})"
+    );
+}
+
+#[test]
+fn unique_cow_disjoint() {
+    // Two states mutating completely different indices — no shared COW nodes.
+    let base = List::<u64, U1048576>::try_from_iter(0..10000u64).unwrap();
+    let mut s1 = base.clone();
+    *s1.get_mut(0).unwrap() = 111;
+    s1.apply_updates().unwrap();
+
+    let mut s2 = base.clone();
+    *s2.get_mut(9999).unwrap() = 222;
+    s2.apply_updates().unwrap();
+
+    let base_tree = base.tree_root();
+    let individual_sum = s1.cow_bytes(&base) + s2.cow_bytes(&base);
+    let unique =
+        crate::mem::total_unique_cow_tree_bytes(base_tree, &[s1.tree_root(), s2.tree_root()]);
+
+    // Disjoint mutations: no shared COW nodes (except possibly root).
+    // Unique should be close to (but possibly slightly less than) the sum
+    // because the root node might be counted once instead of twice.
+    assert!(unique > 0);
+    assert!(unique <= individual_sum);
+}
+
+#[test]
+fn unique_cow_empty() {
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let base_tree = base.tree_root();
+    let unique = crate::mem::total_unique_cow_tree_bytes(base_tree, &[]);
+    assert_eq!(unique, 0);
+}
+
+#[test]
+fn unique_cow_clone_only() {
+    // Clone without mutation — should be 0.
+    let base = List::<u64, U1048576>::try_from_iter(0..1000u64).unwrap();
+    let clone = base.clone();
+    let base_tree = base.tree_root();
+    let unique = crate::mem::total_unique_cow_tree_bytes(base_tree, &[clone.tree_root()]);
+    assert_eq!(unique, 0);
+}

--- a/src/tests/mem.rs
+++ b/src/tests/mem.rs
@@ -321,3 +321,74 @@ fn measure_mainnet_field_sizes() {
         total as f64 / 1048576.0
     );
 }
+
+#[test]
+fn unique_cow_finalization_advance() {
+    // Simulate finalization advance:
+    // F_old is the original base. S1..S4 are slot transitions from F_old (few mutations).
+    // F_new is an epoch boundary state (all entries rewritten) from F_old.
+    // After finalization, F_new becomes the base.
+    //
+    // total_unique_cow_tree_bytes(F_new, [S1..S4]) should NOT count the full tree
+    // per state — the dedup HashSet should catch that S1..S4 all share F_old's nodes.
+
+    let f_old = List::<u64, U1048576>::try_from_iter(0..10_000u64).unwrap();
+
+    // F_new: epoch boundary, ALL entries rewritten (completely new tree)
+    let mut f_new = f_old.clone();
+    for i in 0..10_000 {
+        *f_new.get_mut(i).unwrap() = (i as u64).wrapping_add(1_000_000);
+    }
+    f_new.apply_updates().unwrap();
+
+    // S1..S4: slot transitions from F_old, few mutations each
+    let mut states = Vec::new();
+    for s in 0..4 {
+        let mut si = f_old.clone();
+        for j in 0..10 {
+            let idx = (s * 137 + j * 31) % 10_000;
+            *si.get_mut(idx).unwrap() = u64::MAX;
+        }
+        si.apply_updates().unwrap();
+        states.push(si);
+    }
+
+    // Measure using F_old as base (the correct base) — should be small
+    let refs_old: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+    let with_old_base = crate::mem::total_unique_cow_tree_bytes(f_old.tree_root(), &refs_old);
+
+    // Measure using F_new as base (what happens after finalization) — should ALSO be
+    // reasonable because the HashSet deduplicates F_old's shared nodes across states
+    let refs_new: Vec<_> = states.iter().map(|s| s.tree_root()).collect();
+    let with_new_base = crate::mem::total_unique_cow_tree_bytes(f_new.tree_root(), &refs_new);
+
+    let full_tree = f_old.total_tree_bytes();
+
+    eprintln!("with_old_base = {with_old_base}");
+    eprintln!("with_new_base = {with_new_base}");
+    eprintln!("full_tree     = {full_tree}");
+    eprintln!("naive per-state cow_bytes vs F_new:");
+    for (i, s) in states.iter().enumerate() {
+        eprintln!("  S{i}: {}", s.cow_bytes(&f_new));
+    }
+
+    // with_old_base: just the dirty paths from S1..S4 (small)
+    assert!(
+        with_old_base < full_tree / 4,
+        "with_old_base ({with_old_base}) should be much less than full tree ({full_tree})"
+    );
+
+    // with_new_base: F_old's tree counted ONCE (from S1's walk) + dirty paths.
+    // Should be roughly full_tree + small delta, NOT 4 × full_tree.
+    assert!(
+        with_new_base < full_tree * 2,
+        "with_new_base ({with_new_base}) should be < 2× full tree ({full_tree}) thanks to dedup"
+    );
+
+    // Naive per-state sum would be ~4 × full_tree (each state counted independently)
+    let naive_sum: usize = states.iter().map(|s| s.cow_bytes(&f_new)).sum();
+    assert!(
+        with_new_base < naive_sum / 2,
+        "dedup ({with_new_base}) should be much less than naive sum ({naive_sum})"
+    );
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -102,6 +102,18 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> Vector<T, N, U> {
         Ok(self.interface.iter_cow_from(index))
     }
 
+    /// Compute the bytes owned by `self` that are not shared with `base`.
+    ///
+    /// O(dirty_nodes) — shared subtrees are skipped via `Arc::ptr_eq`.
+    pub fn cow_bytes(&self, base: &Self) -> usize {
+        crate::mem::cow_tree_bytes(&base.interface.backing.tree, &self.interface.backing.tree)
+    }
+
+    /// Total bytes of all tree nodes (no sharing baseline).
+    pub fn total_tree_bytes(&self) -> usize {
+        crate::mem::total_tree_bytes(&self.interface.backing.tree)
+    }
+
     // Wrap trait methods so we present a Vec-like interface without having to import anything.
     pub fn get(&self, index: usize) -> Option<&'_ T> {
         self.interface.get(index)


### PR DESCRIPTION
## Summary

Add `cow_bytes(base, derived)` for measuring the COW memory cost of a derived tree
relative to its base. Walks both trees in parallel — when `Arc` pointers match, the
subtree is shared and skipped immediately. Only divergent nodes are visited and counted.

This is intended for Lighthouse's state cache byte budget: measuring how many bytes
each cached state owns beyond the shared finalized base, cheaply enough to run on
every slot transition.

## Benchmarks (1M u64 entries, capacity 2^40)

| Dirty leaves | cow_bytes | MemoryTracker |
|-------------|-----------|---------------|
| 0 (clone) | 1.1 ns | 450 ms |
| 1 | 180 ns | 450 ms |
| 128 | 5.8 µs | 450 ms |
| 10,000 | 511 µs | 450 ms |
| 1,000,000 (all) | 4.6 ms | 450 ms |

## API

- `List::cow_bytes(&self, base: &Self) -> usize`
- `List::total_tree_bytes(&self) -> usize`
- `Vector::cow_bytes(&self, base: &Self) -> usize`
- `Vector::total_tree_bytes(&self) -> usize`
- `mem::cow_tree_bytes(base, derived)` — raw `Arc<Tree<T>>` version
- `mem::total_tree_bytes(tree)` — full size, no sharing baseline

## Test plan

- [x] `cow_bytes_identical_is_zero` — clone has 0 cost
- [x] `cow_bytes_single_mutation` — single dirty leaf, cost << total
- [x] `cow_bytes_all_dirty` — all leaves dirty, cost ≈ total
- [x] `cow_bytes_matches_tracker_differential` — agrees with MemoryTracker within List struct overhead
- [x] `cow_bytes_vector` — works on Vector too
- [x] `cow_bytes_chain` — A→B→C: C vs A >= C vs B
- [x] `total_tree_bytes_nonzero` — sanity check
- [x] All 278 existing tests pass