### PR TITLE
Delete `bulk_update`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,6 @@ pub enum Error {
     BuilderStackEmptyFinalize,
     BuilderStackLeftover,
     BuilderFull,
-    BulkUpdateUnclean,
     CowMissingEntry,
     LevelIterPendingUpdates,
     IntraRebaseZeroHash,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -136,14 +136,6 @@ where
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
-    pub fn bulk_update(&mut self, updates: U) -> Result<(), Error> {
-        if !self.updates.is_empty() {
-            return Err(Error::BulkUpdateUnclean);
-        }
-        self.updates = updates;
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/src/list.rs
+++ b/src/list.rs
@@ -195,10 +195,6 @@ impl<T: Value, N: Unsigned, U: UpdateMap<T>> List<T, N, U> {
         self.interface.apply_updates()
     }
 
-    pub fn bulk_update(&mut self, updates: U) -> Result<(), Error> {
-        self.interface.bulk_update(updates)
-    }
-
     pub(crate) fn depth() -> usize {
         if let Some(packing_bits) = opt_packing_depth::<T>() {
             int_log(N::to_usize()).saturating_sub(packing_bits)


### PR DESCRIPTION
Its semantics are unsound: it allows injecting an arbitrary update map which can create gaps in the set of keys.

We don't use `bulk_update` in Lighthouse and it was previously untested.

This unsoundness surfaced as part of the verification effort in:

- https://github.com/sigp/milhouse/pull/104