### PR TITLE
Fix max_index interaction with CoW pointers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,9 @@ harness = false
 name = "pop_front"
 harness = false
 
+[[bench]]
+name = "cow"
+harness = false
+
 [profile.bench]
 debug = true

--- a/benches/cow.rs
+++ b/benches/cow.rs
@@ -1,0 +1,80 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use milhouse::List;
+use std::hint::black_box;
+
+type Capacity = typenum::U1048576;
+
+const LEN: usize = 16_384;
+const INDEX: usize = LEN / 2;
+
+fn bench_cow(c: &mut Criterion) {
+    let base = List::<u64, Capacity>::try_from_iter(0..LEN as u64).unwrap();
+    let mut group = c.benchmark_group("cow");
+
+    let mut list = base.clone();
+    group.bench_function("get_backing", |b| {
+        b.iter(|| {
+            let cow = black_box(&mut list).get_cow(black_box(INDEX)).unwrap();
+            black_box(*cow)
+        });
+    });
+
+    let mut list = base.clone();
+    *list.get_mut(INDEX).unwrap() = u64::MAX;
+    group.bench_function("get_updated", |b| {
+        b.iter(|| {
+            let cow = black_box(&mut list).get_cow(black_box(INDEX)).unwrap();
+            black_box(*cow)
+        });
+    });
+
+    group.bench_function("into_mut_backing", |b| {
+        b.iter_batched_ref(
+            || base.clone(),
+            |list| {
+                let cow = black_box(list).get_cow(black_box(INDEX)).unwrap();
+                *cow.into_mut().unwrap() = black_box(u64::MAX);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let mut list = base.clone();
+    *list.get_mut(INDEX).unwrap() = u64::MAX;
+    group.bench_function("into_mut_updated", |b| {
+        b.iter(|| {
+            let cow = black_box(&mut list).get_cow(black_box(INDEX)).unwrap();
+            *cow.into_mut().unwrap() = black_box(0);
+        });
+    });
+
+    let mut list = base.clone();
+    group.bench_with_input(BenchmarkId::new("iter_read", LEN), &LEN, |b, _| {
+        b.iter(|| {
+            let mut sum = 0u64;
+            let mut iter = black_box(&mut list).iter_cow();
+            while let Some((_, cow)) = iter.next_cow() {
+                sum = black_box(sum.wrapping_add(*cow));
+            }
+            black_box(sum)
+        });
+    });
+
+    group.bench_with_input(BenchmarkId::new("iter_mut", LEN), &LEN, |b, _| {
+        b.iter_batched_ref(
+            || base.clone(),
+            |list| {
+                let mut iter = black_box(list).iter_cow();
+                while let Some((_, cow)) = iter.next_cow() {
+                    *cow.into_mut().unwrap() = black_box(u64::MAX);
+                }
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cow);
+criterion_main!(benches);

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -3,8 +3,8 @@ use std::collections::btree_map::VacantEntry;
 use std::ops::Deref;
 
 pub enum Cow<'a, T: Clone> {
-    BTree(BTreeCow<'a, T>),
-    Vec(VecCow<'a, T>),
+    BTree(BTreeCow<'a, T>, Option<Box<dyn FnOnce() + 'a>>),
+    Vec(VecCow<'a, T>, Option<Box<dyn FnOnce() + 'a>>),
 }
 
 impl<T: Clone> Deref for Cow<'_, T> {
@@ -12,8 +12,8 @@ impl<T: Clone> Deref for Cow<'_, T> {
 
     fn deref(&self) -> &T {
         match self {
-            Self::BTree(cow) => cow.deref(),
-            Self::Vec(cow) => cow.deref(),
+            Self::BTree(cow, _) => cow.deref(),
+            Self::Vec(cow, _) => cow.deref(),
         }
     }
 }
@@ -21,16 +21,52 @@ impl<T: Clone> Deref for Cow<'_, T> {
 impl<'a, T: Clone> Cow<'a, T> {
     pub fn into_mut(self) -> Result<&'a mut T, Error> {
         match self {
-            Self::BTree(cow) => cow.into_mut(),
-            Self::Vec(cow) => cow.into_mut(),
+            Self::BTree(cow, on_mut) => {
+                let value = cow.into_mut()?;
+                if let Some(on_mut) = on_mut {
+                    on_mut();
+                }
+                Ok(value)
+            }
+            Self::Vec(cow, on_mut) => {
+                let value = cow.into_mut()?;
+                if let Some(on_mut) = on_mut {
+                    on_mut();
+                }
+                Ok(value)
+            }
         }
     }
 
     pub fn make_mut(&mut self) -> Result<&mut T, Error> {
         match self {
-            Self::BTree(cow) => cow.make_mut(),
-            Self::Vec(cow) => cow.make_mut(),
+            Self::BTree(cow, on_mut) => {
+                let value = cow.make_mut()?;
+                if let Some(on_mut) = on_mut.take() {
+                    on_mut();
+                }
+                Ok(value)
+            }
+            Self::Vec(cow, on_mut) => {
+                let value = cow.make_mut()?;
+                if let Some(on_mut) = on_mut.take() {
+                    on_mut();
+                }
+                Ok(value)
+            }
         }
+    }
+
+    pub(crate) fn with_on_mut<F>(mut self, on_mut: F) -> Self
+    where
+        F: FnOnce() + 'a,
+    {
+        match &mut self {
+            Self::BTree(_, callback) | Self::Vec(_, callback) => {
+                *callback = Some(Box::new(on_mut));
+            }
+        }
+        self
     }
 }
 
@@ -133,5 +169,46 @@ impl<T: Clone> Deref for VecCow<'_, T> {
             Self::Immutable { value, .. } => value,
             Self::Mutable { value } => value,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cow, VecCow};
+    use crate::Error;
+    use std::cell::Cell;
+
+    #[test]
+    fn on_mut_callback_runs_once() {
+        let mut value = 1;
+        let callback_count = Cell::new(0);
+        let mut cow = Cow::Vec(VecCow::Mutable { value: &mut value }, None)
+            .with_on_mut(|| callback_count.set(callback_count.get() + 1));
+
+        *cow.make_mut().expect("mutable cow should remain mutable") = 2;
+        *cow.make_mut().expect("mutable cow should remain mutable") = 3;
+        drop(cow);
+
+        assert_eq!(callback_count.get(), 1);
+        assert_eq!(value, 3);
+    }
+
+    #[test]
+    fn on_mut_callback_does_not_run_on_error() {
+        let value = 1;
+        let callback_count = Cell::new(0);
+        let mut cow = Cow::Vec(
+            VecCow::Immutable {
+                value: &value,
+                entry: None,
+            },
+            None,
+        )
+        .with_on_mut(|| callback_count.set(callback_count.get() + 1));
+
+        assert_eq!(cow.make_mut(), Err(Error::CowMissingEntry));
+        drop(cow);
+
+        assert_eq!(callback_count.get(), 0);
     }
 }

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -1,10 +1,29 @@
 use crate::Error;
+use crate::update_map::MaxIndexState;
 use std::collections::btree_map::VacantEntry;
 use std::ops::Deref;
 
+/// State updated when a [`Cow`] is made mutable.
+///
+/// This is public because it is part of the public `Cow` variants, but its contents are an
+/// implementation detail.
+#[doc(hidden)]
+#[derive(Default)]
+pub struct CowOnMut<'a> {
+    max_index: Option<(&'a mut MaxIndexState, usize)>,
+}
+
+impl CowOnMut<'_> {
+    fn run(&mut self) {
+        if let Some((max_index, index)) = self.max_index.take() {
+            max_index.record_insert(index);
+        }
+    }
+}
+
 pub enum Cow<'a, T: Clone> {
-    BTree(BTreeCow<'a, T>, Option<Box<dyn FnOnce() + 'a>>),
-    Vec(VecCow<'a, T>, Option<Box<dyn FnOnce() + 'a>>),
+    BTree(BTreeCow<'a, T>, CowOnMut<'a>),
+    Vec(VecCow<'a, T>, CowOnMut<'a>),
 }
 
 impl<T: Clone> Deref for Cow<'_, T> {
@@ -21,18 +40,14 @@ impl<T: Clone> Deref for Cow<'_, T> {
 impl<'a, T: Clone> Cow<'a, T> {
     pub fn into_mut(self) -> Result<&'a mut T, Error> {
         match self {
-            Self::BTree(cow, on_mut) => {
+            Self::BTree(cow, mut on_mut) => {
                 let value = cow.into_mut()?;
-                if let Some(on_mut) = on_mut {
-                    on_mut();
-                }
+                on_mut.run();
                 Ok(value)
             }
-            Self::Vec(cow, on_mut) => {
+            Self::Vec(cow, mut on_mut) => {
                 let value = cow.into_mut()?;
-                if let Some(on_mut) = on_mut {
-                    on_mut();
-                }
+                on_mut.run();
                 Ok(value)
             }
         }
@@ -42,28 +57,21 @@ impl<'a, T: Clone> Cow<'a, T> {
         match self {
             Self::BTree(cow, on_mut) => {
                 let value = cow.make_mut()?;
-                if let Some(on_mut) = on_mut.take() {
-                    on_mut();
-                }
+                on_mut.run();
                 Ok(value)
             }
             Self::Vec(cow, on_mut) => {
                 let value = cow.make_mut()?;
-                if let Some(on_mut) = on_mut.take() {
-                    on_mut();
-                }
+                on_mut.run();
                 Ok(value)
             }
         }
     }
 
-    pub(crate) fn with_on_mut<F>(mut self, on_mut: F) -> Self
-    where
-        F: FnOnce() + 'a,
-    {
+    pub(crate) fn with_max_index(mut self, max_index: &'a mut MaxIndexState, index: usize) -> Self {
         match &mut self {
-            Self::BTree(_, callback) | Self::Vec(_, callback) => {
-                *callback = Some(Box::new(on_mut));
+            Self::BTree(_, on_mut) | Self::Vec(_, on_mut) => {
+                on_mut.max_index = Some((max_index, index));
             }
         }
         self
@@ -174,41 +182,39 @@ impl<T: Clone> Deref for VecCow<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cow, VecCow};
+    use super::{Cow, CowOnMut, VecCow};
     use crate::Error;
-    use std::cell::Cell;
+    use crate::update_map::MaxIndexState;
 
     #[test]
-    fn on_mut_callback_runs_once() {
+    fn on_mut_records_max_index_once() {
         let mut value = 1;
-        let callback_count = Cell::new(0);
-        let mut cow = Cow::Vec(VecCow::Mutable { value: &mut value }, None)
-            .with_on_mut(|| callback_count.set(callback_count.get() + 1));
+        let mut max_index = MaxIndexState::Empty;
+        let mut cow = Cow::Vec(VecCow::Mutable { value: &mut value }, CowOnMut::default())
+            .with_max_index(&mut max_index, 3);
 
         *cow.make_mut().expect("mutable cow should remain mutable") = 2;
         *cow.make_mut().expect("mutable cow should remain mutable") = 3;
-        drop(cow);
 
-        assert_eq!(callback_count.get(), 1);
+        assert_eq!(max_index, MaxIndexState::Known(3));
         assert_eq!(value, 3);
     }
 
     #[test]
-    fn on_mut_callback_does_not_run_on_error() {
+    fn on_mut_does_not_record_max_index_on_error() {
         let value = 1;
-        let callback_count = Cell::new(0);
+        let mut max_index = MaxIndexState::Empty;
         let mut cow = Cow::Vec(
             VecCow::Immutable {
                 value: &value,
                 entry: None,
             },
-            None,
+            CowOnMut::default(),
         )
-        .with_on_mut(|| callback_count.set(callback_count.get() + 1));
+        .with_max_index(&mut max_index, 3);
 
         assert_eq!(cow.make_mut(), Err(Error::CowMissingEntry));
-        drop(cow);
 
-        assert_eq!(callback_count.get(), 0);
+        assert_eq!(max_index, MaxIndexState::Empty);
     }
 }

--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -70,7 +70,7 @@ impl<T: Clone> UpdateMap<T> for BTreeMap<usize, T> {
                 value: entry.into_mut(),
             },
         };
-        Some(Cow::BTree(cow))
+        Some(Cow::BTree(cow, None))
     }
 
     fn insert(&mut self, idx: usize, value: T) -> Option<T> {
@@ -134,7 +134,7 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
                 value: entry.into_mut(),
             },
         };
-        Some(Cow::Vec(cow))
+        Some(Cow::Vec(cow, None))
     }
 
     fn insert(&mut self, idx: usize, value: T) -> Option<T> {
@@ -175,8 +175,6 @@ enum MaxIndexState {
     Empty,
     /// The largest index in the inner map is known exactly.
     Known(usize),
-    /// The inner map may have been modified through a lazily materialized `Cow`.
-    Unknown,
 }
 
 impl MaxIndexState {
@@ -184,9 +182,6 @@ impl MaxIndexState {
         match self {
             Self::Empty => *self = Self::Known(index),
             Self::Known(max_index) => *max_index = (*max_index).max(index),
-            // An insert cannot repair an already-unknown maximum: the inner map may contain a
-            // larger index that was inserted through a `Cow`.
-            Self::Unknown => {}
         }
     }
 }
@@ -232,13 +227,10 @@ where
         F: FnOnce(usize) -> Option<&'a T>,
         T: Clone + 'a,
     {
-        let cow = self.inner.get_cow_with(k, f)?;
+        let Self { inner, max_index } = self;
+        let cow = inner.get_cow_with(k, f)?;
 
-        // A `Cow` inserts lazily, when it is made mutable. Since that happens after this
-        // method returns, the exact maximum is no longer known. An occupied entry cannot
-        // introduce a new index, so it preserves the existing state.
-        self.max_index = MaxIndexState::Unknown;
-        Some(cow)
+        Some(cow.with_on_mut(move || max_index.record_insert(k)))
     }
 
     fn insert(&mut self, k: usize, value: T) -> Option<T> {
@@ -262,7 +254,6 @@ where
         match self.max_index {
             MaxIndexState::Empty => None,
             MaxIndexState::Known(max_index) => Some(max_index),
-            MaxIndexState::Unknown => self.inner.max_index(),
         }
     }
 }
@@ -270,9 +261,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{MaxIndexState, MaxMap, UpdateMap};
+    use std::collections::BTreeMap;
     use vec_map::VecMap;
 
     type TestMap = MaxMap<VecMap<u64>>;
+    type TestBTreeMap = MaxMap<BTreeMap<usize, u64>>;
 
     #[test]
     fn max_map_defaults_to_empty() {
@@ -310,7 +303,22 @@ mod tests {
             .expect("backing value should produce a Cow");
         *cow.into_mut().expect("Cow should have a vacant entry") = 171;
 
-        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index, MaxIndexState::Known(17));
+        assert_eq!(map.max_index(), Some(17));
+    }
+
+    #[test]
+    fn max_map_tracks_btree_cow_insertions() {
+        let mut map = TestBTreeMap::default();
+        map.insert(3, 30);
+        let backing_value = 170;
+
+        let cow = map
+            .get_cow_with(17, |_| Some(&backing_value))
+            .expect("backing value should produce a Cow");
+        *cow.into_mut().expect("Cow should have a vacant entry") = 171;
+
+        assert_eq!(map.max_index, MaxIndexState::Known(17));
         assert_eq!(map.max_index(), Some(17));
     }
 
@@ -324,8 +332,9 @@ mod tests {
             .get_cow_with(17, |_| Some(&backing_value))
             .expect("backing value should produce a Cow");
         *cow.make_mut().expect("Cow should have a vacant entry") = 171;
+        drop(cow);
 
-        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index, MaxIndexState::Known(17));
         assert_eq!(map.max_index(), Some(17));
     }
 
@@ -340,28 +349,31 @@ mod tests {
             .get_cow_with(17, |_| Some(&backing_value))
             .expect("backing value should produce a Cow");
         assert_eq!(*cow, backing_value);
+        drop(cow);
 
-        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index, MaxIndexState::Known(3));
         assert_eq!(map.max_index(), Some(3));
         assert_eq!(map, expected);
     }
 
     #[test]
-    fn max_map_keeps_known_state_for_cow_of_existing_entry() {
+    fn max_map_tracks_mutation_of_existing_entry() {
         let mut map = TestMap::default();
         map.insert(3, 30);
 
-        let cow = map
+        let mut cow = map
             .get_cow_with(3, |_| None)
             .expect("existing entry should produce a Cow");
-        assert_eq!(*cow, 30);
+        *cow.make_mut().expect("existing entry should be mutable") = 31;
+        drop(cow);
 
-        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index, MaxIndexState::Known(3));
         assert_eq!(map.max_index(), Some(3));
+        assert_eq!(map.get(3), Some(&31));
     }
 
     #[test]
-    fn max_map_insert_does_not_overwrite_unknown_maximum() {
+    fn max_map_insert_preserves_cow_maximum() {
         let mut map = TestMap::default();
         map.insert(3, 30);
         let backing_value = 170;
@@ -372,7 +384,7 @@ mod tests {
         *cow.into_mut().expect("Cow should have a vacant entry") = 171;
         map.insert(10, 100);
 
-        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index, MaxIndexState::Known(17));
         assert_eq!(map.max_index(), Some(17));
     }
 }

--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -24,6 +24,7 @@ pub trait UpdateMap<T>: Default + Clone {
     where
         F: FnMut(usize, &T) -> ControlFlow<(), Result<(), E>>;
 
+    /// Return the largest index currently stored in the map.
     fn max_index(&self) -> Option<usize>;
 
     fn len(&self) -> usize;
@@ -167,7 +168,7 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary),
@@ -177,6 +178,14 @@ pub struct MaxMap<M> {
     #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     inner: M,
     max_key: usize,
+    #[cfg_attr(feature = "arbitrary", arbitrary(default))]
+    max_key_dirty: bool,
+}
+
+impl<M: PartialEq> PartialEq for MaxMap<M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
 }
 
 impl<T, M> UpdateMap<T> for MaxMap<M>
@@ -191,7 +200,11 @@ where
     where
         F: FnOnce(usize) -> Option<T>,
     {
-        self.inner.get_mut_with(k, f)
+        let value = self.inner.get_mut_with(k, f)?;
+        if !self.max_key_dirty && k > self.max_key {
+            self.max_key = k;
+        }
+        Some(value)
     }
 
     fn get_cow_with<'a, F>(&'a mut self, k: usize, f: F) -> Option<Cow<'a, T>>
@@ -199,11 +212,16 @@ where
         F: FnOnce(usize) -> Option<&'a T>,
         T: Clone + 'a,
     {
-        self.inner.get_cow_with(k, f)
+        let cow = self.inner.get_cow_with(k, f)?;
+
+        // A `Cow` inserts lazily, when it is made mutable. Since that happens after this method
+        // returns, invalidate the cache and let `max_index` consult the inner map if needed.
+        self.max_key_dirty = true;
+        Some(cow)
     }
 
     fn insert(&mut self, k: usize, value: T) -> Option<T> {
-        if k > self.max_key {
+        if !self.max_key_dirty && k > self.max_key {
             self.max_key = k;
         }
         self.inner.insert(k, value)
@@ -221,6 +239,74 @@ where
     }
 
     fn max_index(&self) -> Option<usize> {
-        (!self.inner.is_empty()).then_some(self.max_key)
+        if self.inner.is_empty() {
+            None
+        } else if self.max_key_dirty {
+            self.inner.max_index()
+        } else {
+            Some(self.max_key)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MaxMap, UpdateMap};
+    use vec_map::VecMap;
+
+    type TestMap = MaxMap<VecMap<u64>>;
+
+    #[test]
+    fn max_map_tracks_get_mut_with_insertions() {
+        let mut map = TestMap::default();
+
+        assert!(map.get_mut_with(3, |_| Some(30)).is_some());
+        assert_eq!(map.max_index(), Some(3));
+
+        assert!(map.get_mut_with(17, |_| Some(170)).is_some());
+        assert_eq!(map.max_index(), Some(17));
+
+        assert!(map.get_mut_with(23, |_| None).is_none());
+        assert_eq!(map.max_index(), Some(17));
+    }
+
+    #[test]
+    fn max_map_tracks_cow_into_mut_insertions() {
+        let mut map = TestMap::default();
+        map.insert(3, 30);
+        let backing_value = 170;
+
+        let cow = map.get_cow_with(17, |_| Some(&backing_value)).unwrap();
+        *cow.into_mut().unwrap() = 171;
+
+        assert_eq!(map.max_index(), Some(17));
+    }
+
+    #[test]
+    fn max_map_tracks_cow_make_mut_insertions() {
+        let mut map = TestMap::default();
+        map.insert(3, 30);
+        let backing_value = 170;
+
+        let mut cow = map.get_cow_with(17, |_| Some(&backing_value)).unwrap();
+        *cow.make_mut().unwrap() = 171;
+        drop(cow);
+
+        assert_eq!(map.max_index(), Some(17));
+    }
+
+    #[test]
+    fn max_map_ignores_read_only_cow_access() {
+        let mut map = TestMap::default();
+        map.insert(3, 30);
+        let expected = map.clone();
+        let backing_value = 170;
+
+        let cow = map.get_cow_with(17, |_| Some(&backing_value)).unwrap();
+        assert_eq!(*cow, backing_value);
+        drop(cow);
+
+        assert_eq!(map.max_index(), Some(3));
+        assert_eq!(map, expected);
     }
 }

--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -168,6 +168,29 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum MaxIndexState {
+    /// The inner map is known to be empty.
+    #[default]
+    Empty,
+    /// The largest index in the inner map is known exactly.
+    Known(usize),
+    /// The inner map may have been modified through a lazily materialized `Cow`.
+    Unknown,
+}
+
+impl MaxIndexState {
+    fn record_insert(&mut self, index: usize) {
+        match self {
+            Self::Empty => *self = Self::Known(index),
+            Self::Known(max_index) => *max_index = (*max_index).max(index),
+            // An insert cannot repair an already-unknown maximum: the inner map may contain a
+            // larger index that was inserted through a `Cow`.
+            Self::Unknown => {}
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(
     feature = "arbitrary",
@@ -177,9 +200,8 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
 pub struct MaxMap<M> {
     #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     inner: M,
-    max_key: usize,
     #[cfg_attr(feature = "arbitrary", arbitrary(default))]
-    max_key_dirty: bool,
+    max_index: MaxIndexState,
 }
 
 impl<M: PartialEq> PartialEq for MaxMap<M> {
@@ -201,9 +223,7 @@ where
         F: FnOnce(usize) -> Option<T>,
     {
         let value = self.inner.get_mut_with(k, f)?;
-        if !self.max_key_dirty && k > self.max_key {
-            self.max_key = k;
-        }
+        self.max_index.record_insert(k);
         Some(value)
     }
 
@@ -214,17 +234,17 @@ where
     {
         let cow = self.inner.get_cow_with(k, f)?;
 
-        // A `Cow` inserts lazily, when it is made mutable. Since that happens after this method
-        // returns, invalidate the cache and let `max_index` consult the inner map if needed.
-        self.max_key_dirty = true;
+        // A `Cow` inserts lazily, when it is made mutable. Since that happens after this
+        // method returns, the exact maximum is no longer known. An occupied entry cannot
+        // introduce a new index, so it preserves the existing state.
+        self.max_index = MaxIndexState::Unknown;
         Some(cow)
     }
 
     fn insert(&mut self, k: usize, value: T) -> Option<T> {
-        if !self.max_key_dirty && k > self.max_key {
-            self.max_key = k;
-        }
-        self.inner.insert(k, value)
+        let previous = self.inner.insert(k, value);
+        self.max_index.record_insert(k);
+        previous
     }
 
     fn for_each_range<F, E>(&self, start: usize, end: usize, f: F) -> Result<(), E>
@@ -239,34 +259,43 @@ where
     }
 
     fn max_index(&self) -> Option<usize> {
-        if self.inner.is_empty() {
-            None
-        } else if self.max_key_dirty {
-            self.inner.max_index()
-        } else {
-            Some(self.max_key)
+        match self.max_index {
+            MaxIndexState::Empty => None,
+            MaxIndexState::Known(max_index) => Some(max_index),
+            MaxIndexState::Unknown => self.inner.max_index(),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{MaxMap, UpdateMap};
+    use super::{MaxIndexState, MaxMap, UpdateMap};
     use vec_map::VecMap;
 
     type TestMap = MaxMap<VecMap<u64>>;
+
+    #[test]
+    fn max_map_defaults_to_empty() {
+        let map = TestMap::default();
+
+        assert_eq!(map.max_index, MaxIndexState::Empty);
+        assert_eq!(map.max_index(), None);
+    }
 
     #[test]
     fn max_map_tracks_get_mut_with_insertions() {
         let mut map = TestMap::default();
 
         assert!(map.get_mut_with(3, |_| Some(30)).is_some());
+        assert_eq!(map.max_index, MaxIndexState::Known(3));
         assert_eq!(map.max_index(), Some(3));
 
         assert!(map.get_mut_with(17, |_| Some(170)).is_some());
+        assert_eq!(map.max_index, MaxIndexState::Known(17));
         assert_eq!(map.max_index(), Some(17));
 
         assert!(map.get_mut_with(23, |_| None).is_none());
+        assert_eq!(map.max_index, MaxIndexState::Known(17));
         assert_eq!(map.max_index(), Some(17));
     }
 
@@ -276,9 +305,12 @@ mod tests {
         map.insert(3, 30);
         let backing_value = 170;
 
-        let cow = map.get_cow_with(17, |_| Some(&backing_value)).unwrap();
-        *cow.into_mut().unwrap() = 171;
+        let cow = map
+            .get_cow_with(17, |_| Some(&backing_value))
+            .expect("backing value should produce a Cow");
+        *cow.into_mut().expect("Cow should have a vacant entry") = 171;
 
+        assert_eq!(map.max_index, MaxIndexState::Unknown);
         assert_eq!(map.max_index(), Some(17));
     }
 
@@ -288,10 +320,12 @@ mod tests {
         map.insert(3, 30);
         let backing_value = 170;
 
-        let mut cow = map.get_cow_with(17, |_| Some(&backing_value)).unwrap();
-        *cow.make_mut().unwrap() = 171;
-        drop(cow);
+        let mut cow = map
+            .get_cow_with(17, |_| Some(&backing_value))
+            .expect("backing value should produce a Cow");
+        *cow.make_mut().expect("Cow should have a vacant entry") = 171;
 
+        assert_eq!(map.max_index, MaxIndexState::Unknown);
         assert_eq!(map.max_index(), Some(17));
     }
 
@@ -302,11 +336,43 @@ mod tests {
         let expected = map.clone();
         let backing_value = 170;
 
-        let cow = map.get_cow_with(17, |_| Some(&backing_value)).unwrap();
+        let cow = map
+            .get_cow_with(17, |_| Some(&backing_value))
+            .expect("backing value should produce a Cow");
         assert_eq!(*cow, backing_value);
-        drop(cow);
 
+        assert_eq!(map.max_index, MaxIndexState::Unknown);
         assert_eq!(map.max_index(), Some(3));
         assert_eq!(map, expected);
+    }
+
+    #[test]
+    fn max_map_keeps_known_state_for_cow_of_existing_entry() {
+        let mut map = TestMap::default();
+        map.insert(3, 30);
+
+        let cow = map
+            .get_cow_with(3, |_| None)
+            .expect("existing entry should produce a Cow");
+        assert_eq!(*cow, 30);
+
+        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index(), Some(3));
+    }
+
+    #[test]
+    fn max_map_insert_does_not_overwrite_unknown_maximum() {
+        let mut map = TestMap::default();
+        map.insert(3, 30);
+        let backing_value = 170;
+
+        let cow = map
+            .get_cow_with(17, |_| Some(&backing_value))
+            .expect("backing value should produce a Cow");
+        *cow.into_mut().expect("Cow should have a vacant entry") = 171;
+        map.insert(10, 100);
+
+        assert_eq!(map.max_index, MaxIndexState::Unknown);
+        assert_eq!(map.max_index(), Some(17));
     }
 }

--- a/src/update_map.rs
+++ b/src/update_map.rs
@@ -1,4 +1,4 @@
-use crate::cow::{BTreeCow, Cow, VecCow};
+use crate::cow::{BTreeCow, Cow, CowOnMut, VecCow};
 use crate::utils::max_btree_index;
 use std::collections::{BTreeMap, btree_map::Entry};
 use std::ops::ControlFlow;
@@ -70,7 +70,7 @@ impl<T: Clone> UpdateMap<T> for BTreeMap<usize, T> {
                 value: entry.into_mut(),
             },
         };
-        Some(Cow::BTree(cow, None))
+        Some(Cow::BTree(cow, CowOnMut::default()))
     }
 
     fn insert(&mut self, idx: usize, value: T) -> Option<T> {
@@ -134,7 +134,7 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
                 value: entry.into_mut(),
             },
         };
-        Some(Cow::Vec(cow, None))
+        Some(Cow::Vec(cow, CowOnMut::default()))
     }
 
     fn insert(&mut self, idx: usize, value: T) -> Option<T> {
@@ -169,7 +169,7 @@ impl<T: Clone> UpdateMap<T> for VecMap<T> {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum MaxIndexState {
+pub(crate) enum MaxIndexState {
     /// The inner map is known to be empty.
     #[default]
     Empty,
@@ -178,7 +178,7 @@ enum MaxIndexState {
 }
 
 impl MaxIndexState {
-    fn record_insert(&mut self, index: usize) {
+    pub(crate) fn record_insert(&mut self, index: usize) {
         match self {
             Self::Empty => *self = Self::Known(index),
             Self::Known(max_index) => *max_index = (*max_index).max(index),
@@ -230,7 +230,7 @@ where
         let Self { inner, max_index } = self;
         let cow = inner.get_cow_with(k, f)?;
 
-        Some(cow.with_on_mut(move || max_index.record_insert(k)))
+        Some(cow.with_max_index(max_index, k))
     }
 
     fn insert(&mut self, k: usize, value: T) -> Option<T> {
@@ -332,7 +332,6 @@ mod tests {
             .get_cow_with(17, |_| Some(&backing_value))
             .expect("backing value should produce a Cow");
         *cow.make_mut().expect("Cow should have a vacant entry") = 171;
-        drop(cow);
 
         assert_eq!(map.max_index, MaxIndexState::Known(17));
         assert_eq!(map.max_index(), Some(17));
@@ -349,7 +348,6 @@ mod tests {
             .get_cow_with(17, |_| Some(&backing_value))
             .expect("backing value should produce a Cow");
         assert_eq!(*cow, backing_value);
-        drop(cow);
 
         assert_eq!(map.max_index, MaxIndexState::Known(3));
         assert_eq!(map.max_index(), Some(3));
@@ -365,7 +363,6 @@ mod tests {
             .get_cow_with(3, |_| None)
             .expect("existing entry should produce a Cow");
         *cow.make_mut().expect("existing entry should be mutable") = 31;
-        drop(cow);
 
         assert_eq!(map.max_index, MaxIndexState::Known(3));
         assert_eq!(map.max_index(), Some(3));


### PR DESCRIPTION
The LLMs are choking in the progressive containers branch on a bug in `MaxMap`:

- https://github.com/sigp/milhouse/pull/82#discussion_r3893060512

This PR fixes the issue using a callback inside the `Cow` enum to update the `max_index`. This comes with some performance penalty however.

